### PR TITLE
Add hexadecimal binary output conversion option

### DIFF
--- a/doc/mdb-export.txt
+++ b/doc/mdb-export.txt
@@ -10,16 +10,16 @@ DESCRIPTION
   It produces a CSV (comma separated value) output for the given table. Such output is suitable for importation into databases or spreadsheets.
 
 OPTIONS
-  -H                  Suppress header row
-  -Q                  Don't wrap text-like fields (text, memo, date) in quotes.  If not specified text fiels will be surrounded by " (double quote) characters.
-  -d                  Specify an alternative column delimiter If no delimiter is specified, table names will be delimited by a , (comma) character.
-  -R                  Specify a row delimiter
-  -I backend          INSERT statements (instead of CSV). You must specify which SQL backend dialect to use. Allowed values are: access, sybase, oracle, postgres, mysql and sqlite.
-  -D                  Set the date format (see strftime(3) for details)
-  -q                  Use to wrap text-like fields. Default is ".
-  -X                  Use to escape quoted characters within a field.  Default is doubling.
-  -N namespace        Prefix identifiers with namespace.
-  -b strip|raw|octal  Binary export mode: strip binaries, export as-is, or output \ooo style octal data.
+  -H                      Suppress header row
+  -Q                      Don't wrap text-like fields (text, memo, date) in quotes.  If not specified text fiels will be surrounded by " (double quote) characters.
+  -d                      Specify an alternative column delimiter If no delimiter is specified, table names will be delimited by a , (comma) character.
+  -R                      Specify a row delimiter
+  -I backend              INSERT statements (instead of CSV). You must specify which SQL backend dialect to use. Allowed values are: access, sybase, oracle, postgres, mysql and sqlite.
+  -D                      Set the date format (see strftime(3) for details)
+  -q                      Use to wrap text-like fields. Default is ".
+  -X                      Use to escape quoted characters within a field.  Default is doubling.
+  -N namespace            Prefix identifiers with namespace.
+  -b strip|raw|octal|hex  Binary export mode: strip binaries, export as-is, output \ooo style octal data or output \xx style hexadecimal data.
 
 
 NOTES 

--- a/include/mdbtools.h
+++ b/include/mdbtools.h
@@ -180,7 +180,8 @@ enum {
 enum {
 	MDB_BINEXPORT_STRIP,
 	MDB_BINEXPORT_RAW,
-	MDB_BINEXPORT_OCTAL
+	MDB_BINEXPORT_OCTAL,
+	MDB_BINEXPORT_HEXADECIMAL
 };
 
 #define IS_JET4(mdb) (mdb->f->jet_version==MDB_VER_JET4) /* obsolete */


### PR DESCRIPTION
This commit adds another binary output conversion option to convert
binary blobs into hexadecimal notation, similar to the output of the
following command:
  xxd -p binaryfile.bin | tr -d '\n'

(In other words, a single line string of hexadecimal characters
representing a binary blob)

When exporting SQL INSERT statements for SQLite and PostgreSQL and when
the hexadecimal notation is specified with 'mdb-export -b hex ...',
special consideration is given to ensure that binary blobs are safely
written to the SQLite or PostgreSQL database.

Signed-off-by: David Hicks david@hicks.id.au
