### PR TITLE
added (trivial) mdb-count utility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,5 @@ Tim Retout <tim@retout.co.uk>
 Nirgal Vourgère <jmb_deb@nirgal.com>
 	postgres fixes and adds, bug fixes
 
+@kodonnell
+    added (trivial) mdb-count utility

--- a/README
+++ b/README
@@ -12,6 +12,8 @@ pieces are:
               mdb-export -- export table to CSV format.
               mdb-tables -- a simple dump of table names to be used with shell
                             scripts
+              mdb-count  -- a simple count of number of rows in a table, to be
+                            used in shell scripts and ETL pipelines
               mdb-header -- generates a C header to be used in exporting mdb
                             data to a C prog.
               mdb-parsecsv -- generates a C program given a CSV file made with

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS = bash-completion
-bin_PROGRAMS	=	mdb-export mdb-array mdb-schema mdb-tables mdb-parsecsv mdb-header mdb-sql mdb-ver mdb-prop 
+bin_PROGRAMS	=	mdb-export mdb-array mdb-schema mdb-tables mdb-parsecsv mdb-header mdb-sql mdb-ver mdb-prop mdb-count
 noinst_PROGRAMS = mdb-import prtable prcat prdata prkkd prdump prole updrow prindex
 LIBS	=	$(GLIB_LIBS) @LIBS@ @LEXLIB@ 
 DEFS = @DEFS@ -DLOCALEDIR=\"$(localedir)\"

--- a/src/util/mdb-count.c
+++ b/src/util/mdb-count.c
@@ -1,0 +1,55 @@
+/* MDB Tools - A library for reading MS Access database file
+ * Copyright (C) 2000 Brian Bruns
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "mdbtools.h"
+
+int main(int argc, char **argv) {
+    
+    unsigned int i;
+    MdbHandle *mdb;
+    MdbCatalogEntry *entry;
+    MdbTableDef *table;
+    int found = 0;
+
+	if (argc < 3) {
+		fprintf(stderr, "Usage: %s <file> <table>\n", argv[0]);
+		exit(1);
+	}
+	
+    // open db and try to read table:
+	mdb = mdb_open(argv[1], MDB_NOFLAGS);
+	mdb_read_catalog(mdb, MDB_TABLE);
+	for (i = 0; i < mdb->num_catalog; i++) {
+		entry = g_ptr_array_index(mdb->catalog, i);
+		if (entry->object_type == MDB_TABLE && !strcmp(entry->object_name, argv[2])) {
+            table = mdb_read_table(entry);
+            fprintf(stdout, "%d\n", table->num_rows);
+            found = 1;
+            break;
+		}
+	}
+    
+    // check was found:
+	if (!found) {
+		fprintf(stderr, "No table named %s found.\n", argv[2]);
+        exit(1);
+	}
+
+	mdb_close(mdb);
+	return 0;
+}


### PR DESCRIPTION
A very simple utility for giving the number of rows in an mdb file.

#### Why?

Largely, I imagine, for auditing and in ETL pipelines. For example, we have had some (non-reproducible) truncation errors with mdb-export when under high load, and we can use this to confirm that the count of the exported file matches the count of the mdb table.

#### How?

Basically a trivial fork of ./src/util/prtable.c . An alternative would be to make prtable.c an exported utility, as one could then easily do e.g. `prtable <mdb> <table> | grep "number of datarows"` i.e. we leave the extraction of specific bits of information to the user. If that's the case, we can close this PR - I'm putting it here in case it's useful to others.