### PR TITLE
Print unknown Jet versions in libmdb

### DIFF
--- a/src/libmdb/file.c
+++ b/src/libmdb/file.c
@@ -232,7 +232,7 @@ MdbHandle *mdb_open(const char *filename, MdbFileFlags flags)
 		mdb->fmt = &MdbJet4Constants;
 		break;
 	default:
-		fprintf(stderr,"Unknown Jet version.\n");
+		fprintf(stderr,"Unknown Jet version: %x\n", mdb->f->jet_version);
 		mdb_close(mdb);
 		return NULL; 
 	}


### PR DESCRIPTION
Small change to help out debugging Access file compatibility issues.