### PR TITLE
Stop truncating memo fields over 16k

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Mon Jul  6 19:00:00 AWST 2017 Rob Hills <rhills@medimorphosis.com.au>
+    * include/mdbtools.h: increased MDB_BIND_SIZE from 16k to 128k to prevent truncation of large memo field data
+    * src/util/mdb-export.c: removed re-definition of MDB_BIND_SIZE to stop it overriding the definition in mdbtools.h
+
 Tue Aug 30 08:51:31 EDT 2016 Brian Bruns <brian@bruns.com>
 	* bug fix for 'bad' data with odd number of UCS-2 bytes
 

--- a/include/mdbtools.h
+++ b/include/mdbtools.h
@@ -49,7 +49,7 @@
 #define MDB_MAX_IDX_COLS 10
 #define MDB_CATALOG_PG 18
 #define MDB_MEMO_OVERHEAD 12
-#define MDB_BIND_SIZE 16384
+#define MDB_BIND_SIZE (256*1024) /* increased from 16k to 256k to prevent truncation of larger memo field data */
 
 // Theses 2 atrbutes are not supported by all compilers:
 // M$VC see http://stackoverflow.com/questions/1113409/attribute-constructor-equivalent-in-vc

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -22,9 +22,6 @@
 #include "dmalloc.h"
 #endif
 
-#undef MDB_BIND_SIZE
-#define MDB_BIND_SIZE 200000
-
 #define is_quote_type(x) (x==MDB_TEXT || x==MDB_OLE || x==MDB_MEMO || x==MDB_DATETIME || x==MDB_BINARY || x==MDB_REPID)
 #define is_binary_type(x) (x==MDB_OLE || x==MDB_BINARY || x==MDB_REPID)
 


### PR DESCRIPTION
Our MDB data included memo fields that were over 16K in size and this data was being truncated by mdb-export.  This change increases the limit to 256k.  It has been tested against a MDB containing memo field data up to 32k in size.

This change addresses issue #118 