### PR TITLE
Dynamic allocation of MdbSQL->bound_values

### DIFF
--- a/include/mdbsql.h
+++ b/include/mdbsql.h
@@ -20,8 +20,7 @@ typedef struct {
 	MdbTableDef *cur_table;
 	MdbSargNode *sarg_tree;
 	GList *sarg_stack;
-	/* FIX ME */
-	void *bound_values[256];
+	GPtrArray *bound_values;
 	unsigned char *kludge_ttable_pg;
 	long max_rows;
 	char error_msg[1024];
@@ -59,6 +58,7 @@ extern MdbSQL *_mdb_sql(MdbSQL *sql);
 extern MdbSQL *mdb_sql_init();
 extern MdbSQLSarg *mdb_sql_alloc_sarg();
 extern MdbHandle *mdb_sql_open(MdbSQL *sql, char *db_name);
+extern void mdb_sql_free_tree(MdbSargNode *tree);
 extern int mdb_sql_add_sarg(MdbSQL *sql, char *col_name, int op, char *constant);
 extern void mdb_sql_all_columns(MdbSQL *sql);
 extern int mdb_sql_add_column(MdbSQL *sql, char *column_name);
@@ -78,6 +78,7 @@ extern MdbSQL* mdb_sql_run_query (MdbSQL*, const gchar*);
 extern void mdb_sql_set_maxrow(MdbSQL *sql, int maxrow);
 extern int mdb_sql_eval_expr(MdbSQL *sql, char *const1, int op, char *const2);
 extern void mdb_sql_bind_all(MdbSQL *sql);
+extern void mdb_sql_unbind_all(MdbSQL *sql);
 extern int mdb_sql_fetch_row(MdbSQL *sql, MdbTableDef *table);
 extern int mdb_sql_add_temp_col(MdbSQL *sql, MdbTableDef *ttable, int col_num, char *name, int col_type, int col_size, int is_fixed);
 extern void mdb_sql_bind_column(MdbSQL *sql, int colnum, void *varaddr, int *len_ptr);

--- a/src/sql/mdbsql.c
+++ b/src/sql/mdbsql.c
@@ -77,6 +77,7 @@ MdbSQL *sql;
 	sql = (MdbSQL *) g_malloc0(sizeof(MdbSQL));
 	sql->columns = g_ptr_array_new();
 	sql->tables = g_ptr_array_new();
+	sql->bound_values = g_ptr_array_new();
 	sql->sarg_tree = NULL;
 	sql->sarg_stack = NULL;
 	sql->max_rows = -1;
@@ -154,6 +155,34 @@ static void mdb_sql_free_tables(GPtrArray *tables)
 		g_free(t);
 	}
 	g_ptr_array_free(tables, TRUE);
+}
+
+/* This gives us a nice, uniform place to keep up with memory that needs to be freed */
+static void mdb_sql_free(MdbSQL *sql)
+{
+	/* Free MdbTableDef structures	*/
+	if (sql->cur_table) {
+		mdb_index_scan_free(sql->cur_table);
+		mdb_free_tabledef(sql->cur_table);
+		sql->cur_table = NULL;
+	}
+
+	/* Free MdbSQLColumns and MdbSQLTables */
+	mdb_sql_free_columns(sql->columns);
+	mdb_sql_free_tables(sql->tables);
+
+	/* Free sargs */
+	if (sql->sarg_tree) {
+		mdb_sql_free_tree(sql->sarg_tree);
+		sql->sarg_tree = NULL;
+	}
+
+	g_list_free(sql->sarg_stack);
+	sql->sarg_stack = NULL;
+
+	/* Free bindings  */
+	mdb_sql_unbind_all(sql);
+	g_ptr_array_free(sql->bound_values, TRUE);
 }
 
 void
@@ -457,39 +486,24 @@ void mdb_sql_dump(MdbSQL *sql)
 }
 void mdb_sql_exit(MdbSQL *sql)
 {
-	mdb_sql_reset(sql); // Free memory
+	mdb_sql_free(sql);
 	if (sql->mdb)
 		mdb_close(sql->mdb);
 }
 void mdb_sql_reset(MdbSQL *sql)
 {
-	if (sql->cur_table) {
-		mdb_index_scan_free(sql->cur_table);
-		if (sql->cur_table->sarg_tree) {
-			mdb_sql_free_tree(sql->cur_table->sarg_tree);
-			sql->cur_table->sarg_tree = NULL;
-		}
-		mdb_free_tabledef(sql->cur_table);
-		sql->cur_table = NULL;
-	}
+	mdb_sql_free(sql);
 
 	/* Reset columns */
-	mdb_sql_free_columns(sql->columns);
 	sql->num_columns = 0;
 	sql->columns = g_ptr_array_new();
 
-	/* Reset tables */
-	mdb_sql_free_tables(sql->tables);
+	/* Reset MdbSQL tables */
 	sql->num_tables = 0;
 	sql->tables = g_ptr_array_new();
 
-	/* Reset sargs */
-	if (sql->sarg_tree) {
-		mdb_sql_free_tree(sql->sarg_tree);
-		sql->sarg_tree = NULL;
-	}
-	g_list_free(sql->sarg_stack);
-	sql->sarg_stack = NULL;
+	/* Reset bindings */
+	sql->bound_values = g_ptr_array_new();
 
 	sql->all_columns = 0;
 	sql->max_rows = -1;
@@ -733,12 +747,24 @@ void
 mdb_sql_bind_all(MdbSQL *sql)
 {
 	unsigned int i;
+	void *bound_value;
 
 	for (i=0;i<sql->num_columns;i++) {
-		sql->bound_values[i] = g_malloc0(MDB_BIND_SIZE);
-		mdb_sql_bind_column(sql, i+1, sql->bound_values[i], NULL);
+		bound_value = g_malloc0(MDB_BIND_SIZE);
+		g_ptr_array_add(sql->bound_values, bound_value);
+		mdb_sql_bind_column(sql, i+1, bound_value, NULL);
 	}
 }
+
+void mdb_sql_unbind_all(MdbSQL *sql)
+{
+	unsigned int i;
+
+	for (i=0;i<sql->bound_values->len;i++) {
+		g_free(g_ptr_array_index(sql->bound_values, i));
+	}
+}
+
 /*
  * mdb_sql_fetch_row is now just a wrapper around mdb_fetch_row.
  *   It is left here only for backward compatibility.
@@ -776,7 +802,7 @@ mdb_sql_dump_results(MdbSQL *sql)
 	while(mdb_fetch_row(sql->cur_table)) {
   		for (j=0;j<sql->num_columns;j++) {
 			sqlcol = g_ptr_array_index(sql->columns,j);
-			print_value(sql->bound_values[j],sqlcol->disp_size,!j);
+			print_value(g_ptr_array_index(sql->bound_values, j),sqlcol->disp_size,!j);
 		}
 		fprintf(stdout,"\n");
 	}
@@ -788,10 +814,6 @@ mdb_sql_dump_results(MdbSQL *sql)
 	}
 
 	fprintf(stdout,"\n");
-	/* clean up */
-	for (j=0;j<sql->num_columns;j++) {
-		g_free(sql->bound_values[j]);
-	}
 
 	/* the column and table names are no good now */
 	mdb_sql_reset(sql);

--- a/src/util/mdb-sql.c
+++ b/src/util/mdb-sql.c
@@ -272,11 +272,11 @@ dump_results(FILE *out, MdbSQL *sql, char *delimiter)
 		row_count++;
   		for (j=0;j<sql->num_columns-1;j++) {
 			sqlcol = g_ptr_array_index(sql->columns,j);
-			fprintf(out, "%s%s", (char*)(sql->bound_values[j]),
+			fprintf(out, "%s%s", (char*)(g_ptr_array_index(sql->bound_values, j)),
 				delimiter ? delimiter : "\t");
 		}
 		sqlcol = g_ptr_array_index(sql->columns,sql->num_columns-1);
-		fprintf(out, "%s", (char*)(sql->bound_values[sql->num_columns-1]));
+		fprintf(out, "%s", (char*)(g_ptr_array_index(sql->bound_values, sql->num_columns-1)));
 		fprintf(out,"\n");
 		fflush(out);
 	}
@@ -324,7 +324,7 @@ dump_results_pp(FILE *out, MdbSQL *sql)
 		row_count++;
   		for (j=0;j<sql->num_columns;j++) {
 			sqlcol = g_ptr_array_index(sql->columns,j);
-			print_value(out, sql->bound_values[j],sqlcol->disp_size,!j);
+			print_value(out, (char *) g_ptr_array_index(sql->bound_values, j), sqlcol->disp_size,!j);
 		}
 		fprintf(out,"\n");
 		fflush(out);
@@ -341,11 +341,7 @@ dump_results_pp(FILE *out, MdbSQL *sql)
 		print_rows_retrieved(out, row_count);
 	}
 
-	/* clean up */
-	for (j=0;j<sql->num_columns;j++) {
-		g_free(sql->bound_values[j]);
-	}
-
+	/* Bound values cleaned up in reset */
 	mdb_sql_reset(sql);
 }
 


### PR DESCRIPTION
> Was previously hardcoded to 256 columns max.

I'm creating pull requests out of the stale branches on the original repository. Please leave a comment if you find this change useful (or problematic).