### PR TITLE
mdb-sql should use semicolon separators

### DIFF
--- a/README
+++ b/README
@@ -65,7 +65,7 @@ If you want to build the ODBC driver, you'll need unixodbc (version 2.2.10 or
 above) or iodbc.
 
 If you want to build man pages, you'll need txt2man. Source is available at
-http://mvertes.free.fr/download/.
+https://github.com/mvertes/txt2man.
 
 If you want to generate the html version of the docbook, you'll need openjade
 and basic dsl catalogs.
@@ -74,7 +74,7 @@ and basic dsl catalogs.
 Installation from source:
 =========================
 
-Last version is available at https://github.com/brianb/mdbtools
+Last version is available at https://github.com/mdbtools/mdbtools
 
   $ autoreconf -i -f
 
@@ -117,7 +117,7 @@ The mailing list from the old site is available at
 http://mdbtools.sourceforge.net
 
 Please send bug repports to the new github platform.
-https://github.com/brianb/mdbtools/issues
+https://github.com/mdbtools/mdbtools/issues
 
 
 Brian Bruns

--- a/src/util/mdb-sql.c
+++ b/src/util/mdb-sql.c
@@ -443,15 +443,16 @@ main(int argc, char **argv)
 		if (s) free(s);
 
 		if (in) {
-			s=malloc(256);
-			if ((!s) || (!fgets(s, 256, in))) {
-				/* if we have something in the buffer, run it */
+			s=malloc(bufsz);
+			if (!fgets(s, bufsz, in)) {
+				// Backwards compatibility with older MDBTools
+				// Files read from the command line had an
+				// implicit "go" at the end
 				if (strlen(mybuf))
-					run_query((out) ? out : stdout,
-					          sql, mybuf, delimiter);
-				break;
-			}
-			if (s[strlen(s)-1]=='\n')
+					strcpy(s, "go");
+				else
+					break;
+			} else if (s[strlen(s)-1]=='\n')
 				s[strlen(s)-1]=0;
 		} else {
 			sprintf(prompt, "%d => ", line);
@@ -483,8 +484,8 @@ main(int argc, char **argv)
 				mybuf = (char *) g_realloc(mybuf, bufsz);
 			}
 #ifdef HAVE_READLINE_HISTORY
-			/* don't record blank lines */
-			if (strlen(s)) add_history(s);
+			/* don't record blank lines, or lines read from files */
+			if (!in && strlen(s)) add_history(s);
 #endif
 			strcat(mybuf,s);
 			/* preserve line numbering for the parser */


### PR DESCRIPTION
This is a proposed fix for issue #168 .

Semicolons can now be used as separators from SQL entered at the mdb-sql prompt, or loaded from files on the command line or by ":r".

The old functionality (enter "go" to execute the SQL) still works, because:
1. backwards compatibility,
2. some mdbtools (such as mdb-queries?) might export SQL statements that need the old functionality, and
3. Microsoft's sqlcmd tool does it that way.  mdb-sql appears to be a clone of this tool.