### PR TITLE
Support "SELECT TOP n [PERCENT]... " queries.

### DIFF
--- a/include/mdbsql.h
+++ b/include/mdbsql.h
@@ -50,6 +50,7 @@ typedef struct MdbSQL
 	long max_rows;
 	char error_msg[1024];
 	int limit;
+	int limit_percent;
 	long row_count;
 } MdbSQL;
 
@@ -103,7 +104,8 @@ void mdb_sql_bind_all(MdbSQL *sql);
 int mdb_sql_fetch_row(MdbSQL *sql, MdbTableDef *table);
 int mdb_sql_add_temp_col(MdbSQL *sql, MdbTableDef *ttable, int col_num, char *name, int col_type, int col_size, int is_fixed);
 void mdb_sql_bind_column(MdbSQL *sql, int colnum, void *varaddr, int *len_ptr);
-int mdb_sql_add_limit(MdbSQL *sql, char *limit);
+int mdb_sql_add_limit(MdbSQL *sql, char *limit, int percent);
+int mdb_sql_get_limit(MdbSQL *sql);
 
 
 int parse_sql(MdbSQL * mdb, const gchar* str);

--- a/src/sql/lexer.l
+++ b/src/sql/lexer.l
@@ -72,6 +72,8 @@ null		{ return NUL; }
 ">"		{ return GT; }
 like		{ return LIKE; }
 limit		{ return LIMIT; }
+top		{ return TOP; }
+percent		{ return PERCENT; }
 count		{ return COUNT; }
 strptime	{ return STRPTIME; }
 [ \t\r]	;

--- a/src/util/mdb-queries.c
+++ b/src/util/mdb-queries.c
@@ -62,9 +62,11 @@ int main (int argc, char **argv) {
 	
 	//variables for the generation of sql
 	char *sql_tables = (char *) malloc(bind_size);
+	char *sql_predicate = (char *) malloc(bind_size);
 	char *sql_columns = (char *) malloc(bind_size);
 	char *sql_where = (char *) malloc(bind_size);
 	char *sql_sorting = (char *) malloc(bind_size);
+	int flagint;
 	
 	/* see getopt(3) for more information on getopt and this will become clear */
 	while ((opt=getopt(argc, argv, "L1d:"))!=-1) {
@@ -148,8 +150,22 @@ int main (int argc, char **argv) {
 
 				while (mdb_fetch_row(table)) {
 					if(strcmp(query_id,objectid) == 0) {
+						flagint = atoi(flag);
 						//we have a row for our query
 						switch(atoi(attribute)) {
+							case 3:		// predicate
+								if (flagint & 0x30) {
+									strcpy(sql_predicate, " TOP ");
+									strcat(sql_predicate, name1);
+									if (flagint & 0x20) {
+										strcat(sql_predicate, " PERCENT");
+									}
+								} else if (flagint & 0x8) {
+									strcpy(sql_predicate, " DISTINCTROW");
+								} else if (flagint & 0x2) {
+									strcpy(sql_predicate, " DISTINCT");
+								}
+								break;
 							case 5:		// table name
 								if(strcmp(sql_tables,"") == 0) {
 									strcpy(sql_tables,name1);
@@ -193,9 +209,9 @@ int main (int argc, char **argv) {
 				
 				/* print out the sql statement */
 				if(strcmp(sql_where,"") == 0) {
-					fprintf(stdout,"SELECT %s FROM %s %s\n",sql_columns,sql_tables,sql_sorting);
+					fprintf(stdout,"SELECT%s %s FROM %s %s\n",sql_predicate,sql_columns,sql_tables,sql_sorting);
 				} else {
-					fprintf(stdout,"SELECT %s FROM %s WHERE %s %s\n",sql_columns,sql_tables,sql_where,sql_sorting);
+					fprintf(stdout,"SELECT%s %s FROM %s WHERE %s %s\n",sql_predicate,sql_columns,sql_tables,sql_where,sql_sorting);
 				}
 						
 				mdb_free_tabledef(table);


### PR DESCRIPTION
Microsoft Access uses "SELECT TOP n [PERCENT]..." instead of "SELECT ... LIMIT n".  This pull request implements that.

I have left in the old LIMIT implementation for backwards compatibility with old versions of MDBTools.  The code will throw an error if the user uses both TOP and LIMIT in the same query.