### PR TITLE
Remove redundant AM_CONDITIONALs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ jobs:
         packages:
         - libiodbc2-dev
         - gawk
+        - gnome-doc-utils
+        - gtk-doc-tools
     env:
       - CONFIGURE_FLAGS="--with-iodbc=/usr --disable-glib"
   - compiler: clang
@@ -20,6 +22,8 @@ jobs:
         - libiodbc2-dev
         - libglib2.0-dev
         - gawk
+        - gnome-doc-utils
+        - gtk-doc-tools
     env:
       - CONFIGURE_FLAGS="--with-iodbc=/usr --enable-glib"
   - compiler: clang
@@ -29,6 +33,8 @@ jobs:
         packages:
         - unixodbc-dev
         - gawk
+        - gnome-doc-utils
+        - gtk-doc-tools
     env:
       - CONFIGURE_FLAGS="--with-unixodbc=/usr --disable-glib"
   - compiler: clang
@@ -39,6 +45,8 @@ jobs:
         - unixodbc-dev
         - libglib2.0-dev
         - gawk
+        - gnome-doc-utils
+        - gtk-doc-tools
     env:
       - CONFIGURE_FLAGS="--with-unixodbc=/usr --enable-glib"
   - compiler: gcc
@@ -48,6 +56,8 @@ jobs:
         packages:
         - libiodbc2-dev
         - gawk
+        - gnome-doc-utils
+        - gtk-doc-tools
     env:
       - CONFIGURE_FLAGS="--with-iodbc=/usr --disable-glib"
   - compiler: gcc
@@ -57,6 +67,8 @@ jobs:
         packages:
         - unixodbc-dev
         - gawk
+        - gnome-doc-utils
+        - gtk-doc-tools
     env:
       - CONFIGURE_FLAGS="--with-unixodbc=/usr --disable-glib"
   - compiler: gcc-10
@@ -69,6 +81,8 @@ jobs:
         - gcc-10
         - libiodbc2-dev
         - gawk
+        - gnome-doc-utils
+        - gtk-doc-tools
     env:
       - CONFIGURE_FLAGS="--with-iodbc=/usr --disable-glib"
   - compiler: gcc-10
@@ -81,6 +95,8 @@ jobs:
         - gcc-10
         - unixodbc-dev
         - gawk
+        - gnome-doc-utils
+        - gtk-doc-tools
     env:
       - CONFIGURE_FLAGS="--with-unixodbc=/usr --disable-glib"
   - compiler: clang
@@ -92,6 +108,7 @@ jobs:
         - libiodbc
         - bison
         - gawk
+        - gtk-doc
     env:
       - CONFIGURE_FLAGS="--with-iodbc=/usr/local/opt --disable-glib"
       - YACC="/usr/local/opt/bison/bin/bison"
@@ -105,6 +122,7 @@ jobs:
         - glib
         - bison
         - gawk
+        - gtk-doc
     env:
       - CONFIGURE_FLAGS="--with-iodbc=/usr/local/opt --enable-glib"
       - YACC="/usr/local/opt/bison/bin/bison"
@@ -117,6 +135,7 @@ jobs:
         - unixodbc
         - bison
         - gawk
+        - gtk-doc
     env:
       - CONFIGURE_FLAGS="--with-unixodbc=/usr/local/opt --disable-glib"
       - YACC="/usr/local/opt/bison/bin/bison"
@@ -130,6 +149,7 @@ jobs:
         - glib
         - bison
         - gawk
+        - gtk-doc
     env:
       - CONFIGURE_FLAGS="--with-unixodbc=/usr/local/opt --enable-glib"
       - YACC="/usr/local/opt/bison/bin/bison"
@@ -142,6 +162,7 @@ jobs:
         - libiodbc
         - bison
         - gawk
+        - gtk-doc
     env:
       - CONFIGURE_FLAGS="--with-iodbc=/usr/local/opt --disable-glib"
       - YACC="/usr/local/opt/bison/bin/bison"
@@ -154,6 +175,7 @@ jobs:
         - unixodbc
         - bison
         - gawk
+        - gtk-doc
     env:
       - CONFIGURE_FLAGS="--with-unixodbc=/usr/local/opt --disable-glib"
       - YACC="/usr/local/opt/bison/bin/bison"

--- a/.travis.yml
+++ b/.travis.yml
@@ -181,11 +181,13 @@ jobs:
       - YACC="/usr/local/opt/bison/bin/bison"
 
 before_script:
+  - pkg-config gnome-doc-utils --modversion
   - git clone https://github.com/mdbtools/mdbtestdata.git test
   - autoreconf -i -f -Wno-portability
 
 script:
   - ./configure --disable-silent-rules $CONFIGURE_FLAGS
+  - cat config.log
   - make
   - ./src/util/mdb-json test/data/ASampleDatabase.accdb "Asset Items"
   - ./src/util/mdb-json test/data/nwind.mdb "Customers"

--- a/configure.ac
+++ b/configure.ac
@@ -284,8 +284,6 @@ if test x$enable_gtk_doc = xauto ; then
 fi
 
 AM_CONDITIONAL(ENABLE_GTK_DOC, test x$enable_gtk_doc = xyes)
-AM_CONDITIONAL(HAVE_GNOME_DOC_UTILS, test x$enable_gtk_doc = xyes)
-AM_CONDITIONAL(ENABLE_SK, test x$enable_gtk_doc = xyes)
 
 ##################################################
 # Check for txt2man


### PR DESCRIPTION
`GNOME_DOC_INIT` defines `ENABLE_SK` and `HAVE_GNOME_DOC_UTILS`, so it's unnecessary to link them to the presence of `GTKDOC`.

A small step toward splitting off gmdb2 into its own project.