### PR TITLE
A couple of issues, #171 and #176

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,7 +197,7 @@ AM_CONDITIONAL(ICONV, test "$am_cv_func_iconv" = "yes")
 
 dnl Testing presence of pkg-config
 AC_MSG_CHECKING([pkg-config m4 macros])
-if test m4_ifdef([PKG_CHECK_MODULES], [yes], [no]) == yes; then
+if test m4_ifdef([PKG_CHECK_MODULES], [yes], [no]) = yes; then
 	AC_MSG_RESULT([yes]);
 else
 	AC_MSG_RESULT([no]);

--- a/include/mdbtools.h
+++ b/include/mdbtools.h
@@ -212,6 +212,8 @@ typedef struct {
 	const MdbBackendType *type_autonum;
 	const char *short_now;
 	const char *long_now;
+	const char *date_fmt;
+	const char *shortdate_fmt;
 	const char *charset_statement;
 	const char *drop_statement;
 	const char *constaint_not_empty_statement;
@@ -543,6 +545,7 @@ void mdb_register_backend(MdbHandle *mdb, char *backend_name, guint32 capabiliti
         const MdbBackendType *type_shortdate,
         const MdbBackendType *type_autonum,
         const char *short_now, const char *long_now,
+        const char *date_fmt, const char *shortdate_fmt,
         const char *charset_statement, const char *drop_statement, const char *constaint_not_empty_statement,
         const char *column_comment_statement, const char *per_column_comment_statement,
         const char *table_comment_statement, const char *per_table_comment_statement,

--- a/src/libmdb/backend.c
+++ b/src/libmdb/backend.c
@@ -305,6 +305,8 @@ void mdb_init_backends(MdbHandle *mdb)
 		MDB_SHEXP_DROPTABLE|MDB_SHEXP_CST_NOTNULL|MDB_SHEXP_DEFVALUES,
 		mdb_access_types, NULL, NULL,
 		"Date()", "Date()",
+		NULL,
+		NULL,
 		"-- That file uses encoding %s\n",
 		"DROP TABLE %s;\n",
 		NULL,
@@ -317,6 +319,8 @@ void mdb_init_backends(MdbHandle *mdb)
 		MDB_SHEXP_DROPTABLE|MDB_SHEXP_CST_NOTNULL|MDB_SHEXP_CST_NOTEMPTY|MDB_SHEXP_COMMENTS|MDB_SHEXP_DEFVALUES,
 		mdb_sybase_types, &mdb_sybase_shortdate_type, NULL,
 		"getdate()", "getdate()",
+		NULL,
+		NULL,
 		"-- That file uses encoding %s\n",
 		"DROP TABLE %s;\n",
 		"ALTER TABLE %s ADD CHECK (%s <>'');\n",
@@ -329,6 +333,8 @@ void mdb_init_backends(MdbHandle *mdb)
 		MDB_SHEXP_DROPTABLE|MDB_SHEXP_CST_NOTNULL|MDB_SHEXP_COMMENTS|MDB_SHEXP_INDEXES|MDB_SHEXP_RELATIONS|MDB_SHEXP_DEFVALUES,
 		mdb_oracle_types, &mdb_oracle_shortdate_type, NULL,
 		"current_date", "sysdate",
+		NULL,
+		NULL,
 		"-- That file uses encoding %s\n",
 		"DROP TABLE %s;\n",
 		NULL,
@@ -341,6 +347,8 @@ void mdb_init_backends(MdbHandle *mdb)
 		MDB_SHEXP_DROPTABLE|MDB_SHEXP_CST_NOTNULL|MDB_SHEXP_CST_NOTEMPTY|MDB_SHEXP_COMMENTS|MDB_SHEXP_INDEXES|MDB_SHEXP_RELATIONS|MDB_SHEXP_DEFVALUES|MDB_SHEXP_BULK_INSERT,
 		mdb_postgres_types, &mdb_postgres_shortdate_type, &mdb_postgres_serial_type,
 		"current_date", "now()",
+		"%Y-%m-%d %H:%M:%S",
+		"%Y-%m-%d",
 		"SET client_encoding = '%s';\n",
 		"DROP TABLE IF EXISTS %s;\n",
 		"ALTER TABLE %s ADD CHECK (%s <>'');\n",
@@ -353,6 +361,8 @@ void mdb_init_backends(MdbHandle *mdb)
 		MDB_SHEXP_DROPTABLE|MDB_SHEXP_CST_NOTNULL|MDB_SHEXP_CST_NOTEMPTY|MDB_SHEXP_INDEXES|MDB_SHEXP_DEFVALUES|MDB_SHEXP_BULK_INSERT,
 		mdb_mysql_types, &mdb_mysql_shortdate_type, NULL,
 		"current_date", "now()",
+		"%Y-%m-%d %H:%M:%S",
+		"%Y-%m-%d",
 		"-- That file uses encoding %s\n",
 		"DROP TABLE IF EXISTS %s;\n",
 		"ALTER TABLE %s ADD CHECK (%s <>'');\n",
@@ -365,6 +375,8 @@ void mdb_init_backends(MdbHandle *mdb)
 		MDB_SHEXP_DROPTABLE|MDB_SHEXP_RELATIONS|MDB_SHEXP_DEFVALUES|MDB_SHEXP_BULK_INSERT,
 		mdb_sqlite_types, NULL, NULL,
 		"date('now')", "date('now')",
+		"%Y-%m-%d %H:%M:%S",
+		"%Y-%m-%d",
 		"-- That file uses encoding %s\n",
 		"DROP TABLE IF EXISTS %s;\n",
 		NULL,
@@ -378,6 +390,7 @@ void mdb_init_backends(MdbHandle *mdb)
 void mdb_register_backend(MdbHandle *mdb, char *backend_name, guint32 capabilities,
         const MdbBackendType *backend_type, const MdbBackendType *type_shortdate, const MdbBackendType *type_autonum,
         const char *short_now, const char *long_now,
+        const char *date_fmt, const char *shortdate_fmt,
         const char *charset_statement, const char *drop_statement,
         const char *constaint_not_empty_statement,
         const char *column_comment_statement,
@@ -393,6 +406,8 @@ void mdb_register_backend(MdbHandle *mdb, char *backend_name, guint32 capabiliti
 	backend->type_autonum = type_autonum;
 	backend->short_now = short_now;
 	backend->long_now = long_now;
+	backend->date_fmt = date_fmt;
+	backend->shortdate_fmt = shortdate_fmt;
 	backend->charset_statement = charset_statement;
 	backend->drop_statement = drop_statement;
 	backend->constaint_not_empty_statement = constaint_not_empty_statement;
@@ -443,6 +458,16 @@ int mdb_set_default_backend(MdbHandle *mdb, const char *backend_name)
 		g_free(mdb->backend_name); // NULL is ok
 		mdb->backend_name = (char *) g_strdup(backend_name);
 		mdb->relationships_table = NULL;
+		if (backend->date_fmt) {
+			mdb_set_date_fmt(mdb, backend->date_fmt);
+		} else {
+			mdb_set_date_fmt(mdb, "%x %X");
+		}
+		if (backend->shortdate_fmt) {
+			mdb_set_shortdate_fmt(mdb, backend->shortdate_fmt);
+		} else {
+			mdb_set_shortdate_fmt(mdb, "%x");
+		}
 		return 1;
 	} else {
 		return 0;

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -1676,7 +1676,7 @@ SQLRETURN SQL_API SQLGetData(
 				return SQL_NO_DATA;
 			}
 			if (pcbValue) {
-				*pcbValue = len + 1 - stmt->pos;
+				*pcbValue = len - stmt->pos;
 			}
 			if (cbValueMax == 0) {
 				free(str);


### PR DESCRIPTION
Sorry for wrapping two different changes into one pull request.  They are fairly minor, though.

I was looked at #171 and noticed that all strings displayed by python had an extra 0x00 on the end. MDBTools ODBC driver had a bug where SQLGetData() returned the length of the string including the NULL terminator, whereas it should return the length without the terminator.

mdb-export would be better if it exports dates with a format that the target database understands, as noted in #176.  So I fixed that for most backends.  I left Oracle and Sybase with their current defaults (which are probably wrong) because I don't have either database to test with.