### PR TITLE
Don't distribute mdbver.h

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,5 +1,5 @@
-include_HEADERS	= mdbtools.h mdbsql.h mdbver.h
+include_HEADERS	= mdbtools.h mdbsql.h
 if FAKE_GLIB
 include_HEADERS += mdbfakeglib.h
 endif
-noinst_HEADERS = mdbprivate.h
+noinst_HEADERS = mdbprivate.h mdbver.h


### PR DESCRIPTION
Hi

I just realized Debian never distributed mdbver.h
Do we want that?

This include seems useless for people using mdbtools. What do you think?