### PR TITLE
Don't include length of '\0' in SQLGetData pcbValue

### DIFF
--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -1676,7 +1676,7 @@ SQLRETURN SQL_API SQLGetData(
 				return SQL_NO_DATA;
 			}
 			if (pcbValue) {
-				*pcbValue = len + 1 - stmt->pos;
+				*pcbValue = len - stmt->pos;
 			}
 			if (cbValueMax == 0) {
 				free(str);


### PR DESCRIPTION
SQLGetData() should return the length of the string without the null terminator.

This needs reviewing to check it works for converted integers and other data types.