### PR TITLE
Bounds check mdb_bind_column()

### DIFF
--- a/include/mdbtools.h
+++ b/include/mdbtools.h
@@ -509,7 +509,7 @@ void mdb_data_dump(MdbTableDef *table);
 void mdb_date_to_tm(double td, struct tm *t);
 void mdb_tm_to_date(struct tm *t, double *td);
 char *mdb_uuid_to_string(const void *buf, int start);
-void mdb_bind_column(MdbTableDef *table, int col_num, void *bind_ptr, int *len_ptr);
+int mdb_bind_column(MdbTableDef *table, int col_num, void *bind_ptr, int *len_ptr);
 int mdb_rewind_table(MdbTableDef *table);
 int mdb_fetch_row(MdbTableDef *table);
 int mdb_is_fixed_col(MdbColumn *col);

--- a/src/libmdb/data.c
+++ b/src/libmdb/data.c
@@ -73,20 +73,31 @@ void mdb_set_boolean_fmt_words(MdbHandle *mdb)
 	mdb->boolean_true_value  = boolean_true_word;
 }
 
-void mdb_bind_column(MdbTableDef *table, int col_num, void *bind_ptr, int *len_ptr)
+int mdb_bind_column(MdbTableDef *table, int col_num, void *bind_ptr, int *len_ptr)
 {
-	MdbColumn *col;
+	MdbColumn *col = NULL;
 
 	/* 
 	** the column arrary is 0 based, so decrement to get 1 based parameter 
 	*/
-	col=g_ptr_array_index(table->columns, col_num - 1);
-	
-	if (bind_ptr)
-		col->bind_ptr = bind_ptr;
-	if (len_ptr)
-		col->len_ptr = len_ptr;
+	col_num--;
+
+	if (col_num >= 0 && col_num < (int)table->num_cols) {
+		col=g_ptr_array_index(table->columns, col_num);
+
+		if (col) {
+			if (bind_ptr)
+				col->bind_ptr = bind_ptr;
+			if (len_ptr)
+				col->len_ptr = len_ptr;
+
+			return 0;
+		}
+	}
+
+	return -1;
 }
+
 int
 mdb_bind_column_by_name(MdbTableDef *table, gchar *col_name, void *bind_ptr, int *len_ptr)
 {

--- a/src/libmdb/data.c
+++ b/src/libmdb/data.c
@@ -91,7 +91,7 @@ int mdb_bind_column(MdbTableDef *table, int col_num, void *bind_ptr, int *len_pt
 			if (len_ptr)
 				col->len_ptr = len_ptr;
 
-			return 0;
+			return col_num + 1;
 		}
 	}
 

--- a/src/libmdb/data.c
+++ b/src/libmdb/data.c
@@ -495,7 +495,7 @@ void mdb_data_dump(MdbTableDef *table)
 		bound_values[i] = (char *) g_malloc(256);
 		ret = mdb_bind_column(table, i+1, bound_values[i], NULL);
 		if (ret == -1) {
-			fprintf(stdout, "error binding column %d\n", i+1);
+			fprintf(stderr, "error binding column %d\n", i+1);
 			g_free(bound_values[i]);
 			bound_values[i] = NULL;
 		}

--- a/src/libmdb/data.c
+++ b/src/libmdb/data.c
@@ -488,16 +488,24 @@ mdb_fetch_row(MdbTableDef *table)
 void mdb_data_dump(MdbTableDef *table)
 {
 	unsigned int i;
+	int ret;
 	char *bound_values[MDB_MAX_COLS]; 
 
 	for (i=0;i<table->num_cols;i++) {
 		bound_values[i] = (char *) g_malloc(256);
-		mdb_bind_column(table, i+1, bound_values[i], NULL);
+		ret = mdb_bind_column(table, i+1, bound_values[i], NULL);
+		if (ret == -1) {
+			fprintf(stdout, "error binding column %d\n", i+1);
+			g_free(bound_values[i]);
+			bound_values[i] = NULL;
+		}
 	}
 	mdb_rewind_table(table);
 	while (mdb_fetch_row(table)) {
 		for (i=0;i<table->num_cols;i++) {
-			fprintf(stdout, "column %d is %s\n", i+1, bound_values[i]);
+			if (bound_values[i]) {
+				fprintf(stdout, "column %d is %s\n", i+1, bound_values[i]);
+			}
 		}
 	}
 	for (i=0;i<table->num_cols;i++) {

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -51,6 +51,7 @@ main(int argc, char **argv)
 	int bin_mode = MDB_BINEXPORT_RAW;
 	char *value;
 	size_t length;
+	int ret;
 
 	GOptionEntry entries[] = {
 		{"no-header", 'H', G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &header_row, "Suppress header row.", NULL},
@@ -172,7 +173,11 @@ main(int argc, char **argv)
 	for (i = 0; i < table->num_cols; i++) {
 		/* bind columns */
 		bound_values[i] = (char *) g_malloc0(EXPORT_BIND_SIZE);
-		mdb_bind_column(table, i + 1, bound_values[i], &bound_lens[i]);
+		ret = mdb_bind_column(table, i + 1, bound_values[i], &bound_lens[i]);
+		if (ret == -1) {
+			fprintf(stderr, "Failed to bind column %d\n", i + 1);
+			exit(1);
+		}
 	}
 	if (header_row) {
 		for (i = 0; i < table->num_cols; i++) {

--- a/src/util/mdb-json.c
+++ b/src/util/mdb-json.c
@@ -112,6 +112,7 @@ main(int argc, char **argv)
 	char *shortdate_fmt = NULL;
 	char *value;
 	size_t length;
+	int ret;
 
 	GOptionEntry entries[] = {
 		{"date-format", 'D', 0, G_OPTION_ARG_STRING, &shortdate_fmt, "Set the date format (see strftime(3) for details)", "format"},
@@ -166,7 +167,11 @@ main(int argc, char **argv)
 	for (i=0;i<table->num_cols;i++) {
 		/* bind columns */
 		bound_values[i] = (char *) g_malloc0(EXPORT_BIND_SIZE);
-		mdb_bind_column(table, i+1, bound_values[i], &bound_lens[i]);
+		ret = mdb_bind_column(table, i+1, bound_values[i], &bound_lens[i]);
+		if (ret == -1) {
+			fprintf(stderr, "Failed to bind column %d\n", i + 1);
+			exit(1);
+		}
 	}
 
 	while(mdb_fetch_row(table)) {

--- a/src/util/sargtest.c
+++ b/src/util/sargtest.c
@@ -64,7 +64,11 @@ MdbSarg sarg;
 	for (j=0;j<table->num_cols;j++) {
 		bound_values[j] = (char *) g_malloc(MDB_BIND_SIZE);
 		bound_values[j][0] = '\0';
-		mdb_bind_column(table, j+1, bound_values[j], NULL);
+		ret = mdb_bind_column(table, j+1, bound_values[j], NULL);
+		if (ret == -1) {
+			fprintf(stderr, "Failed to bind column %d\n", i + 1);
+			exit(1);
+		}
 	}
 
 	/* print header */


### PR DESCRIPTION
Return -1 to report out of bounds column number.

This prevents a segfault when passing an invalid column number to this function.