### PR TITLE
mdb-export: Rename --backend into --insert

### DIFF
--- a/doc/mdb-export.txt
+++ b/doc/mdb-export.txt
@@ -3,7 +3,7 @@ NAME
 
 SYNOPSIS
   mdb-export [--no-header] [--delimiter delim] [--row-delimiter delim] [[--no-quote] | [--quote char [--escape char]]] [--date-format fmt] [--datetime-format fmt] [--bin strip|raw|octal|hex] [--boolean-words] database table
-  mdb-export --backend backend [--namespace prefix] [--batch-size int] database table
+  mdb-export --insert backend [--namespace prefix] [--batch-size int] database table
   mdb-export -h|--help
 
 DESCRIPTION
@@ -20,7 +20,7 @@ OPTIONS
   -Q, --no-quote                Don't wrap text-like fields (text, memo, date) in quotes.  If not specified text fiels will be surrounded by " (double quote) characters.
   -q, --quote char              Use char to wrap text-like fields. Default is " (double quote).
   -X, --escape char             Use char to escape quoted characters within a field. Default is doubling.
-  -I, --backend backend         INSERT statements (instead of CSV). You must specify which SQL backend dialect to use. Allowed values are: access, sybase, oracle, postgres, mysql and sqlite.
+  -I, --insert backend          INSERT statements (instead of CSV). You must specify which SQL backend dialect to use. Allowed values are: access, sybase, oracle, postgres, mysql and sqlite.
   -N, --namespace prefix        Prefix identifiers with prefix.
   -S, --batch-size int          Size of insert batches on supported platforms.
   -D, --date-format fmt         Set the date format (see strftime(3) for details.

--- a/src/util/bash-completion/mdb-export
+++ b/src/util/bash-completion/mdb-export
@@ -8,7 +8,7 @@ _mdb_export()
 
 	if [[ "$prev" == -@(d|-delimiter|R|-row-delimiter|-quote|X|-escape|N|-namespace|S|-batch-size|D|-date-format|T|-datetime-format|0|-null|h|-help) ]] ; then
 		return 0
-	elif [[ "$prev" == -I ]] ; then
+	elif [[ "$prev" == -@(I|-insert) ]] ; then
 		COMPREPLY=( $( compgen -W 'access sybase oracle postgres mysql sqlite' -- $cur ) )
 	elif [[ "$prev" == -@(b|-bin) ]] ; then
 		COMPREPLY=( $( compgen -W 'strip raw octal hex' -- $cur ) )
@@ -16,7 +16,7 @@ _mdb_export()
 		COMPREPLY=( $( compgen -W '-H -d -R -Q -q -X -I -N -S -D -T -0 -B -h \
 		--no-header --delimiter --row-delimiter \
 		--no-quote --quote --escape \
-		--backend --namespace --batch-size \
+		--insert --namespace --batch-size \
 		--date-format --datetime-format \
 		--null --bin --boolean-words
 		--help' -- $cur ) )

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -59,7 +59,7 @@ main(int argc, char **argv)
 		{"no-quote", 'Q', G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &quote_text, "Don't wrap text-like fields in quotes.", NULL},
 		{"quote", 'q', 0, G_OPTION_ARG_STRING, &quote_char, "Use <char> to wrap text-like fields. Default is double quote.", "char"},
 		{"escape", 'X', 0, G_OPTION_ARG_STRING, &escape_char, "Use <char> to escape quoted characters within a field. Default is doubling.", "format"},
-		{"backend", 'I', 0, G_OPTION_ARG_STRING, &insert_dialect, "INSERT statements (instead of CSV)", "backend"},
+		{"insert", 'I', 0, G_OPTION_ARG_STRING, &insert_dialect, "INSERT statements (instead of CSV)", "backend"},
 		{"namespace", 'N', 0, G_OPTION_ARG_STRING, &namespace, "Prefix identifiers with namespace", "namespace"},
 		{"batch-size", 'S', 0, G_OPTION_ARG_INT, &batch_size, "Size of insert batches on supported platforms.", "int"},
 		{"date-format", 'D', 0, G_OPTION_ARG_STRING, &shortdate_fmt, "Set the date format (see strftime(3) for details)", "format"},


### PR DESCRIPTION
mdb-export "-I backend" translates into "--insert backend", not "--backend backend"