### PR TITLE
Large file support on 32-bit systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,9 @@ AC_TYPE_SIZE_T
 AM_ICONV
 AM_GCC_ATTRIBUTE_ALIAS
 
+dnl Enable large files on 32-bit systems
+AC_SYS_LARGEFILE
+
 dnl no optional stuff by default
 OPTDIRS=""
 

--- a/src/libmdb/file.c
+++ b/src/libmdb/file.c
@@ -394,7 +394,7 @@ static ssize_t _mdb_read_pg(MdbHandle *mdb, void *pg_buf, unsigned long pg)
 	ssize_t len;
 	off_t offset = pg * mdb->fmt->pg_size;
 
-    if (fseek(mdb->f->stream, 0, SEEK_END) == -1) {
+    if (fseeko(mdb->f->stream, 0, SEEK_END) == -1) {
         fprintf(stderr, "Unable to seek to end of file\n");
         return 0;
     }
@@ -405,7 +405,7 @@ static ssize_t _mdb_read_pg(MdbHandle *mdb, void *pg_buf, unsigned long pg)
 	if (mdb->stats && mdb->stats->collect) 
 		mdb->stats->pg_reads++;
 
-	if (fseek(mdb->f->stream, offset, SEEK_SET) == -1) {
+	if (fseeko(mdb->f->stream, offset, SEEK_SET) == -1) {
         fprintf(stderr, "Unable to seek to page %lu\n", pg);
         return 0;
     }

--- a/src/libmdb/write.c
+++ b/src/libmdb/write.c
@@ -72,13 +72,13 @@ mdb_write_pg(MdbHandle *mdb, unsigned long pg)
 	ssize_t len;
 	off_t offset = pg * mdb->fmt->pg_size;
 
-    fseek(mdb->f->stream, 0, SEEK_END);
+    fseeko(mdb->f->stream, 0, SEEK_END);
 	/* is page beyond current size + 1 ? */
 	if (ftello(mdb->f->stream) < offset + mdb->fmt->pg_size) {
 		fprintf(stderr,"offset %" PRIu64 " is beyond EOF\n",(uint64_t)offset);
 		return 0;
 	}
-	fseek(mdb->f->stream, offset, SEEK_SET);
+	fseeko(mdb->f->stream, offset, SEEK_SET);
 	len = fwrite(mdb->pg_buf, mdb->fmt->pg_size, 1, mdb->f->stream);
 	if (ferror(mdb->f->stream)) {
 		perror("write");


### PR DESCRIPTION
* Add `AC_SYS_LARGEFILE` to configure.ac

* Replace `fseek` with `fseeko`

See #190