### PR TITLE
Use re-entrant functions in a couple of places

### DIFF
--- a/src/libmdb/options.c
+++ b/src/libmdb/options.c
@@ -24,8 +24,8 @@
 
 #define DEBUG 1
 
-static unsigned long opts;
-static int optset;
+static __thread unsigned long opts;
+static __thread int optset;
 
 static void load_options(void);
 

--- a/src/libmdb/options.c
+++ b/src/libmdb/options.c
@@ -50,9 +50,10 @@ load_options()
 {
 	char *opt;
 	char *s;
+    char *ctx;
 
     if (!optset && (s=getenv("MDBOPTS"))) {
-		opt = strtok(s, ":");
+		opt = strtok_r(s, ":", &ctx);
 		while (opt) {
         	if (!strcmp(opt, "use_index")) opts |= MDB_USE_INDEX;
         	if (!strcmp(opt, "no_memo")) opts |= MDB_NO_MEMO;
@@ -70,7 +71,7 @@ load_options()
 				opts |= MDB_DEBUG_ROW;
 				opts |= MDB_DEBUG_PROPS;
 			}
-			opt = strtok(NULL,":");
+			opt = strtok_r(NULL,":", &ctx);
 		}
     }
 	optset = 1;

--- a/src/sql/mdbsql.c
+++ b/src/sql/mdbsql.c
@@ -760,8 +760,9 @@ int mdb_sql_find_sargcol(MdbSargNode *node, gpointer data)
 		 * Plain integers are UNIX timestamps for backwards compatibility of parser
 		*/
 		if (col->col_type == MDB_DATETIME && node->val_type == MDB_INT) {
-			struct tm *tm = gmtime((time_t*)&node->value.i);
-			mdb_tm_to_date(tm, &node->value.d);
+			struct tm tm;
+			gmtime_r((time_t*)&node->value.i, &tm);
+			mdb_tm_to_date(&tm, &node->value.d);
 			node->val_type = MDB_DOUBLE;
 		}
 	}


### PR DESCRIPTION
Replace `strtok` and `gmtime` with their re-entrant versions. More thread safety work is needed but this is a start.