### PR TITLE
Simplify header-reading logic and support JET3 code pages

### DIFF
--- a/include/mdbtools.h
+++ b/include/mdbtools.h
@@ -246,6 +246,7 @@ typedef struct {
 	unsigned char *free_map;
 	/* reference count */
 	int refs;
+	guint16 code_page;
 } MdbFile; 
 
 /* offset to row count on data pages...version dependant */

--- a/src/libmdb/iconv.c
+++ b/src/libmdb/iconv.c
@@ -253,13 +253,30 @@ void mdb_iconv_init(MdbHandle *mdb)
 		mdb->iconv_out = iconv_open("UCS-2LE", iconv_code);
 		mdb->iconv_in = iconv_open(iconv_code, "UCS-2LE");
 	} else {
-		/* According to Microsoft Knowledge Base pages 289525 and */
-		/* 202427, code page info is not contained in the database */
-		const char *jet3_iconv_code;
-
 		/* check environment variable */
-		if (!(jet3_iconv_code=getenv("MDB_JET3_CHARSET"))) {
-			jet3_iconv_code="CP1252";
+		const char *jet3_iconv_code = getenv("MDB_JET3_CHARSET");
+
+		if (!jet3_iconv_code) {
+			/* Use code page embedded in the database */
+			/* Note that individual columns can override this value,
+			 * but per-column code pages are not supported by libmdb */
+			switch (mdb->f->code_page) {
+				case 874: jet3_iconv_code="WINDOWS-874"; break;
+				case 932: jet3_iconv_code="SHIFT-JIS"; break;
+				case 936: jet3_iconv_code="WINDOWS-936"; break;
+				case 950: jet3_iconv_code="BIG-5"; break;
+				case 951: jet3_iconv_code="BIG5-HKSCS"; break;
+				case 1250: jet3_iconv_code="WINDOWS-1250"; break;
+				case 1251: jet3_iconv_code="WINDOWS-1251"; break;
+				case 1252: jet3_iconv_code="WINDOWS-1252"; break;
+				case 1253: jet3_iconv_code="WINDOWS-1253"; break;
+				case 1254: jet3_iconv_code="WINDOWS-1254"; break;
+				case 1255: jet3_iconv_code="WINDOWS-1255"; break;
+				case 1256: jet3_iconv_code="WINDOWS-1256"; break;
+				case 1257: jet3_iconv_code="WINDOWS-1257"; break;
+				case 1258: jet3_iconv_code="WINDOWS-1258"; break;
+				default: jet3_iconv_code="CP1252"; break;
+			}
 		}
 
 		mdb->iconv_out = iconv_open(jet3_iconv_code, iconv_code);


### PR DESCRIPTION
Using the notes and RC4 key provided in the `HACKING` file, decrypt the database definition page all at once instead of decrypting individual fields with ad-hoc keys. Use the newly decrypted header to access the database code page at offset `0x3C`, and use this numeric value to initialize the iconv converter with an appropriate charset name for popular windows code pages. More encodings can be added later, with the eventual goal of getting rid of the `MDB_JET3_CHARSET` environment variable.

Note that individual columns can have their own code pages but this issue is not addressed.

An extra field is added to the `MdbFile` structure - because this struct is allocated internally, this should not break the public ABI.

Finally, only set the `db_passwd` field if it's a JET3 database (see #144)