### PR TITLE
Turn indexes on by default, if they are expected to work

### DIFF
--- a/src/libmdb/index.c
+++ b/src/libmdb/index.c
@@ -1104,7 +1104,7 @@ mdb_index_scan_init(MdbHandle *mdb, MdbTableDef *table)
 {
 	int i;
 
-	if (mdb_get_option(MDB_USE_INDEX) && mdb_choose_index(table, &i) == MDB_INDEX_SCAN) {
+	if ((IS_JET3(mdb) || mdb_get_option(MDB_USE_INDEX)) && mdb_choose_index(table, &i) == MDB_INDEX_SCAN) {
 		table->strategy = MDB_INDEX_SCAN;
 		table->scan_idx = g_ptr_array_index (table->indices, i);
 		table->chain = g_malloc0(sizeof(MdbIndexChain));

--- a/src/libmdb/options.c
+++ b/src/libmdb/options.c
@@ -52,7 +52,10 @@ load_options()
 	char *s;
     char *ctx;
 
-    if (!optset && (s=getenv("MDBOPTS"))) {
+	if (optset)
+		return;
+
+	if ((s=getenv("MDBOPTS"))) {
 		opt = strtok_r(s, ":", &ctx);
 		while (opt) {
         	if (!strcmp(opt, "use_index")) opts |= MDB_USE_INDEX;
@@ -74,6 +77,9 @@ load_options()
 			opt = strtok_r(NULL,":", &ctx);
 		}
     }
+#ifdef HAVE_LIBMSWSTR
+	opts |= MDB_USE_INDEX;
+#endif
 	optset = 1;
 }
 int


### PR DESCRIPTION
Enable indexes if any of the following hold:

* The database is JET3
* libmswstr is present at configure-time
* `use_index` is present in `MDBOPTS`

See #215 for discussion