### PR TITLE
Added setlocale to support umlauts in mdb-schema 

### DIFF
--- a/include/mdbtools.h
+++ b/include/mdbtools.h
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <string.h>
+#include <locale.h>
 
 #ifdef HAVE_GLIB
 #include <glib.h>
@@ -43,7 +44,6 @@
 #ifdef HAVE_XLOCALE_H
 #include <xlocale.h>
 #endif
-#include <locale.h>
 #endif
 
 #ifdef _WIN32

--- a/src/util/mdb-schema.c
+++ b/src/util/mdb-schema.c
@@ -34,6 +34,8 @@ main (int argc, char **argv)
 	int opt_indexes = MDB_SHEXP_DEFAULT & MDB_SHEXP_INDEXES;
 	int opt_relations = MDB_SHEXP_DEFAULT & MDB_SHEXP_RELATIONS;
 
+	setlocale(LC_ALL, "");
+
 	GOptionEntry entries[] = {
 		{ "table", 'T', 0, G_OPTION_ARG_STRING, &tabname, "Only create schema for named table", "table"},
 		{ "namespace", 'N', 0, G_OPTION_ARG_STRING, &namespace, "Prefix identifiers with namespace", "namespace"},

--- a/test_script.sh
+++ b/test_script.sh
@@ -10,6 +10,7 @@
 ./src/util/mdb-prop test/data/nwind.mdb "Customers"
 ./src/util/mdb-schema test/data/ASampleDatabase.accdb
 ./src/util/mdb-schema test/data/nwind.mdb
+./src/util/mdb-schema test/data/nwind.mdb -T "Umsätze" postgres
 ./src/util/mdb-tables test/data/ASampleDatabase.accdb
 ./src/util/mdb-tables test/data/nwind.mdb
 ./src/util/mdb-ver test/data/ASampleDatabase.accdb


### PR DESCRIPTION
This should be a fix for #234. 
I don't know if the change in `include/mdbtools.h` messed something up as I don't know too much about xlocale.