### PR TITLE
Use correct bind types for SQLBindCol / SQLFetch

### DIFF
--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -303,18 +303,20 @@ SQLRETURN SQL_API SQLExtendedFetch(
 		*rgfRowStatus = SQL_SUCCESS; /* what is the row status value? */
 	
 	if (mdb_fetch_row(stmt->sql->cur_table)) {
-		SQLRETURN retval = SQL_SUCCESS;
-		while (cur && retval == SQL_SUCCESS) {
+		SQLRETURN final_retval = SQL_SUCCESS;
+		while (cur && (final_retval == SQL_SUCCESS || final_retval == SQL_SUCCESS_WITH_INFO)) {
 			/* log error ? */
 			SQLLEN lenbind = 0;
-			retval = SQLGetData(hstmt, cur->column_number, cur->column_bindtype,
+			SQLRETURN this_retval = SQLGetData(hstmt, cur->column_number, cur->column_bindtype,
 					cur->varaddr, cur->column_bindlen, &lenbind);
 			if (cur->column_lenbind)
 				*(cur->column_lenbind) = lenbind;
+			if (this_retval != SQL_SUCCESS)
+				final_retval = this_retval;
 			cur = cur->next;
 		}
 		stmt->rows_affected++;
-		return retval;
+		return final_retval;
 	} else {
 		return SQL_NO_DATA_FOUND;
 	}
@@ -1067,19 +1069,21 @@ SQLRETURN SQL_API SQLFetch(
 		return SQL_NO_DATA_FOUND;
 	}
 	if (mdb_fetch_row(stmt->sql->cur_table)) {
-		SQLRETURN retval = SQL_SUCCESS;
-		while (cur && retval == SQL_SUCCESS) {
+		SQLRETURN final_retval = SQL_SUCCESS;
+		while (cur && (final_retval == SQL_SUCCESS || final_retval == SQL_SUCCESS_WITH_INFO)) {
 			/* log error ? */
 			SQLLEN lenbind = 0;
-			retval = SQLGetData(hstmt, cur->column_number, cur->column_bindtype,
+			SQLRETURN this_retval = SQLGetData(hstmt, cur->column_number, cur->column_bindtype,
 					cur->varaddr, cur->column_bindlen, &lenbind);
 			if (cur->column_lenbind)
 				*(cur->column_lenbind) = lenbind;
+			if (this_retval != SQL_SUCCESS)
+				final_retval = this_retval;
 			cur = cur->next;
 		}
 		stmt->rows_affected++;
 		stmt->pos=0;
-		return retval;
+		return final_retval;
 	} else {
 		return SQL_NO_DATA_FOUND;
 	}

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -309,7 +309,8 @@ SQLRETURN SQL_API SQLExtendedFetch(
 			SQLLEN lenbind = 0;
 			retval = SQLGetData(hstmt, cur->column_number, cur->column_bindtype,
 					cur->varaddr, cur->column_bindlen, &lenbind);
-			*(cur->column_lenbind) = lenbind;
+			if (cur->column_lenbind)
+				*(cur->column_lenbind) = lenbind;
 			cur = cur->next;
 		}
 		stmt->rows_affected++;
@@ -1072,7 +1073,8 @@ SQLRETURN SQL_API SQLFetch(
 			SQLLEN lenbind = 0;
 			retval = SQLGetData(hstmt, cur->column_number, cur->column_bindtype,
 					cur->varaddr, cur->column_bindlen, &lenbind);
-			*(cur->column_lenbind) = lenbind;
+			if (cur->column_lenbind)
+				*(cur->column_lenbind) = lenbind;
 			cur = cur->next;
 		}
 		stmt->rows_affected++;

--- a/src/odbc/unittest.c
+++ b/src/odbc/unittest.c
@@ -160,6 +160,7 @@ int i;
 			  
 	if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) 
 	{
+		long id_value;
 		UCHAR  szCol1[60];
 		SQLLEN length;
 
@@ -179,8 +180,8 @@ int i;
 				szSqlState, szErrorMsg);
 			return 1;
 		}		
+		SQLBindCol(hstmt, 1, SQL_C_LONG, &id_value, sizeof(id_value), NULL);
 		SQLBindCol(hstmt, 3, SQL_CHAR, szCol1, sizeof(szCol1), &length);
-		//SQLBindCol(hstmt, 1, SQL_CHAR, szCol1, 60, NULL);
 	
 		/* Execute statement with first row. */
 
@@ -188,7 +189,7 @@ int i;
 		while ((retcode = SQLFetch(hstmt)) == SQL_SUCCESS)
 		{
 			i++;
-			printf("%d: szCol1 = %s (%d)\n", i, szCol1, (int)length);
+			printf("%d: id = %ld  szCol1 = %s (%d)\n", i, id_value, szCol1, (int)length);
 		}
 		if (retcode != SQL_NO_DATA_FOUND)
 		{


### PR DESCRIPTION
`SQLFetch` now skips the mdb_sql machinery and uses `SQLGetData` on its bound columns instead. We rely on mdb_fetch_row to skip to the correct page (without any bindings) and then `SQLGetData` will do the rest, correctly converting the bound columns to the appropriate types (e.g. integers).

Updated the ODBC unit test, which Works On My Machine, but probably needs more testing overall.

Fixes #23