### PR TITLE
mdb-export: handle MySQL blobs

### DIFF
--- a/src/libmdb/backend.c
+++ b/src/libmdb/backend.c
@@ -114,7 +114,7 @@ static const MdbBackendType mdb_mysql_types[] = {
     [MDB_DATETIME] = { .name = "datetime" },
     [MDB_BINARY] = { .name = "blob" },
     [MDB_TEXT] = { .name = "varchar", .needs_char_length = 1 },
-    [MDB_OLE] = { .name = "varbinary", .needs_byte_length = 1 },
+    [MDB_OLE] = { .name = "blob" },
     [MDB_MEMO] = { .name = "text" },
     [MDB_REPID] = { .name = "char(38)" },
     [MDB_NUMERIC] = { .name = "numeric", .needs_precision = 1, .needs_scale = 1 },

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -24,6 +24,7 @@
 #define is_binary_type(x) (x==MDB_OLE || x==MDB_BINARY || x==MDB_REPID)
 
 static char *escapes(char *s);
+static void format_value(FILE *outfile, char *value, size_t length, int quote_text, int col_type, char *escape_char, char *quote_char, int bin_mode, int export_flags, char *backend_name);
 
 int
 main(int argc, char **argv)
@@ -256,7 +257,11 @@ main(int argc, char **argv)
 						value = bound_values[i];
 						length = bound_lens[i];
 					}
-					mdb_print_col(outfile, value, quote_text, col->col_type, length, quote_char, escape_char, bin_mode | export_flags);
+					format_value(outfile, value, length,
+						     quote_text, col->col_type,
+						     escape_char, quote_char,
+						     bin_mode, export_flags,
+						     mdb->backend_name);
 					if (col->col_type == MDB_OLE)
 						free(value);
 				}
@@ -308,25 +313,11 @@ main(int argc, char **argv)
 						value = bound_values[i];
 						length = bound_lens[i];
 					}
-					/* Correctly handle insertion of binary blobs into SQLite using the string literal notation of X'1234ABCD...' */
-					if (!strcmp(mdb->backend_name, "sqlite") && is_binary_type(col->col_type)
-							&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {
-						char *quote_char_binary_sqlite = (char *) g_strdup("'");
-						fputs("X", outfile);
-						mdb_print_col(outfile, value, quote_text, col->col_type, length, quote_char_binary_sqlite, escape_char, bin_mode | export_flags);
-						g_free (quote_char_binary_sqlite);
-						/* Correctly handle insertion of binary blobs into PostgreSQL using the notation of decode('1234ABCD...', 'hex') */
-					} else if (!strcmp(mdb->backend_name, "postgres") && is_binary_type(col->col_type)
-							&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {
-						char *quote_char_binary_postgres = (char *) g_strdup("'");
-						fputs("decode(", outfile);
-						mdb_print_col(outfile, value, quote_text, col->col_type, length, quote_char_binary_postgres, escape_char, bin_mode | export_flags);
-						fputs(", 'hex')", outfile);
-						g_free (quote_char_binary_postgres);
-						/* No special treatment for other backends or when hexadecimal notation hasn't been selected with the -b hex command line option */
-					} else {
-						mdb_print_col(outfile, value, quote_text, col->col_type, length, quote_char, escape_char, bin_mode | export_flags);
-					}
+					format_value(outfile, value, length,
+						     quote_text, col->col_type,
+						     escape_char, quote_char,
+						     bin_mode, export_flags,
+						     mdb->backend_name);
 					if (col->col_type == MDB_OLE)
 						free(value);
 				}
@@ -358,6 +349,30 @@ main(int argc, char **argv)
 	g_free(str_bin_mode);
 	g_free(table_name);
 	return 0;
+}
+
+static void format_value(FILE *outfile, char *value, size_t length, int quote_text, int col_type, char *escape_char, char *quote_char, int bin_mode, int export_flags, char *backend_name)
+{
+	if (!strcmp(backend_name, "sqlite")
+			&& is_binary_type(col_type)
+			&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {
+		char *quote_char_binary_sqlite = (char *) g_strdup("'");
+		fputs("X", outfile);
+		mdb_print_col(outfile, value, quote_text, col_type, length, quote_char_binary_sqlite, escape_char, bin_mode | export_flags);
+		g_free (quote_char_binary_sqlite);
+		/* Correctly handle insertion of binary blobs into PostgreSQL using the notation of decode('1234ABCD...', 'hex') */
+	} else if (!strcmp(backend_name, "postgres")
+			&& is_binary_type(col_type)
+			&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {
+		char *quote_char_binary_postgres = (char *) g_strdup("'");
+		fputs("decode(", outfile);
+		mdb_print_col(outfile, value, quote_text, col_type, length, quote_char_binary_postgres, escape_char, bin_mode | export_flags);
+		fputs(", 'hex')", outfile);
+		g_free (quote_char_binary_postgres);
+		/* No special treatment for other backends or when hexadecimal notation hasn't been selected with the -b hex command line option */
+	} else {
+		mdb_print_col(outfile, value, quote_text, col_type, length, quote_char, escape_char, bin_mode | export_flags);
+	}
 }
 
 static char *escapes(char *s)

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -362,8 +362,8 @@ static void format_value(FILE *outfile, char *value, size_t length, int quote_te
 		g_free (quote_char_binary_sqlite);
 		/* Correctly handle insertion of binary blobs into PostgreSQL using the notation of decode('1234ABCD...', 'hex') */
 	} else if (!strcmp(backend_name, "mysql")
-		&& is_binary_type(col_type)
-		&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {
+			&& is_binary_type(col_type)
+			&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {
 		char *quote_char_binary_sqlite = (char *) g_strdup("");
 		fputs("0x", outfile);
 		mdb_print_col(outfile, value, quote_text, col_type, length, quote_char_binary_sqlite, escape_char, bin_mode | export_flags);

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -353,6 +353,7 @@ main(int argc, char **argv)
 
 static void format_value(FILE *outfile, char *value, size_t length, int quote_text, int col_type, char *escape_char, char *quote_char, int bin_mode, int export_flags, char *backend_name)
 {
+	/* Correctly handle insertion of binary blobs into sqlite3 using the notation of X'1234ABCD...') */
 	if (!strcmp(backend_name, "sqlite")
 			&& is_binary_type(col_type)
 			&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {
@@ -360,7 +361,7 @@ static void format_value(FILE *outfile, char *value, size_t length, int quote_te
 		fputs("X", outfile);
 		mdb_print_col(outfile, value, quote_text, col_type, length, quote_char_binary_sqlite, escape_char, bin_mode | export_flags);
 		g_free (quote_char_binary_sqlite);
-		/* Correctly handle insertion of binary blobs into PostgreSQL using the notation of decode('1234ABCD...', 'hex') */
+		/* Correctly handle insertion of binary blobs into MySQL using the notation of 0x1234ABCD...) */
 	} else if (!strcmp(backend_name, "mysql")
 			&& is_binary_type(col_type)
 			&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {
@@ -368,6 +369,7 @@ static void format_value(FILE *outfile, char *value, size_t length, int quote_te
 		fputs("0x", outfile);
 		mdb_print_col(outfile, value, quote_text, col_type, length, quote_char_binary_sqlite, escape_char, bin_mode | export_flags);
 		g_free (quote_char_binary_sqlite);
+		/* Correctly handle insertion of binary blobs into PostgreSQL using the notation of decode('1234ABCD...', 'hex') */
 	} else if (!strcmp(backend_name, "postgres")
 			&& is_binary_type(col_type)
 			&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -361,6 +361,13 @@ static void format_value(FILE *outfile, char *value, size_t length, int quote_te
 		mdb_print_col(outfile, value, quote_text, col_type, length, quote_char_binary_sqlite, escape_char, bin_mode | export_flags);
 		g_free (quote_char_binary_sqlite);
 		/* Correctly handle insertion of binary blobs into PostgreSQL using the notation of decode('1234ABCD...', 'hex') */
+	} else if (!strcmp(backend_name, "mysql")
+		&& is_binary_type(col_type)
+		&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {
+		char *quote_char_binary_sqlite = (char *) g_strdup("");
+		fputs("0x", outfile);
+		mdb_print_col(outfile, value, quote_text, col_type, length, quote_char_binary_sqlite, escape_char, bin_mode | export_flags);
+		g_free (quote_char_binary_sqlite);
 	} else if (!strcmp(backend_name, "postgres")
 			&& is_binary_type(col_type)
 			&& bin_mode == MDB_BINEXPORT_HEXADECIMAL) {


### PR DESCRIPTION
This change set fixes exporting BLOBs in the correct MySQL format when that backend is requested.

As a bonus side effect, it also fixes exporting BLOBs for PostgreSQL and SQLite3.

Tested by exporting the northwind.mdb database and loading it into MySQL, PostgreSQL and SQLite3 databases.