### PR TITLE
Add -DHAVE_GLIB to library cflags if needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ MDBTOOLS_VERSION_MICRO=2
 # See https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 VERSION_INFO=3:2:0
 AC_SUBST(VERSION_INFO)
+AC_SUBST(MDBTOOLS_CFLAGS)
 
 AM_MAINTAINER_MODE([enable])
 AM_SILENT_RULES([yes])
@@ -215,6 +216,7 @@ if test "$enable_glib" = "yes"; then
     GLIB_PACKAGE=glib-2.0
     PKG_CHECK_MODULES([GLIB], [$GLIB_PACKAGE], HAVE_GLIB=true, HAVE_GLIB=false)
     if test "x$HAVE_GLIB" = "xtrue"; then
+        MDBTOOLS_CFLAGS="$MDBTOOLS_CFLAGS -DHAVE_GLIB=1"
         GLIB_CFLAGS="$GLIB_CFLAGS -DHAVE_GLIB=1"
         AC_SUBST(GLIB_PACKAGE)
     else

--- a/libmdb.pc.in
+++ b/libmdb.pc.in
@@ -12,4 +12,4 @@ Description: core MDB file support library
 Requires: @GLIB_PACKAGE@
 Version: @VERSION@
 Libs: -L${libdir} -lmdb
-Cflags:
+Cflags: @MDBTOOLS_CFLAGS@


### PR DESCRIPTION
Consumer code including `mdbtools.h` but not specifying `-DHAVE_GLIB` would fail.

This failed when building libgda-5.2.9.

Note: This may be better-solved by judiciously moving the `#include <glib.h>` to the compilation units where it's needed.