### PR TITLE
configure.ac: Respect --libdir for unixODBC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ AC_ARG_WITH(unixodbc,
 if test "$with_unixodbc"; then
 	HAVE_ODBC=true
 	ODBC_CFLAGS="-I$with_unixodbc/include"
-	ODBC_LIBS="-L$with_unixodbc/lib"
+	ODBC_LIBS="-L$with_unixodbc/$libdir"
 	CFLAGS="$CFLAGS -DUNIXODBC"
 
 	dnl SIZEOF_LONG_INT and HAVE_LONG_LONG are required by some versions of unixODBC


### PR DESCRIPTION
When searching for unixODBC, we want to use
the libdir passed in to autotools (--libdir)
to ensure that we find the library
for the correct ABI.

It is possible that we pick up the wrong
copy from e.g. /usr/lib/ where a 32-bit
unixODBC copy of the library exists
when we're in the middle of a 64-bit build.

Use ${libdir} to ensure we respect
any preferences/information given and
search for ODBC in the right place.

Note that this previously affected
us with iODBC but that's since been
resolved by using their
iodbc-config binary.

Bug: https://bugs.gentoo.org/697568
Signed-off-by: Sam James <sam@gentoo.org>