### PR TITLE
fix segfault in SQLGetTypeInfo due pyodbc

### DIFF
--- a/src/libmdb/data.c
+++ b/src/libmdb/data.c
@@ -464,6 +464,8 @@ mdb_fetch_row(MdbTableDef *table)
 	do {
 		if (table->is_temp_table) {
 			GPtrArray *pages = table->temp_table_pages;
+			if (pages->len == 0)
+				return 0;
 			rows = mdb_get_int16(
 				g_ptr_array_index(pages, table->cur_pg_num-1),
 				fmt->row_count_offset);


### PR DESCRIPTION
not all SQL types are supported in type_info. When a client,
e.g. pyodbc, queries for an unsupported type, e.g. SQL_WVARCHAR,
temp_table is empty and further access to it will crash.

Signed-off-by: Ulrich Weber <ulrich.weber@gmail.com>