### PR TITLE
Support more valid uri

### DIFF
--- a/src/sql/lexer.l
+++ b/src/sql/lexer.l
@@ -112,7 +112,7 @@ strptime	{ return STRPTIME; }
 (-?[0-9]+|(-?[0-9]*\.[0-9]+)(e[-+]?[0-9]+)?) {
 		yylval->name = g_strdup(yytext); return NUMBER;
 	}
-~?(\/?[a-z0-9\.\-\xa0-\xff]+)+ {
+~?(\/?[a-z0-9\.\-\_\!\~\*\'\(\)\%\xa0-\xff]+)+ {
 		yylval->name = g_strdup(yytext); return PATH;
 	}
 

--- a/src/sql/lexer.l
+++ b/src/sql/lexer.l
@@ -112,7 +112,7 @@ strptime	{ return STRPTIME; }
 (-?[0-9]+|(-?[0-9]*\.[0-9]+)(e[-+]?[0-9]+)?) {
 		yylval->name = g_strdup(yytext); return NUMBER;
 	}
-~?(\/?[a-z0-9\.\-\_\!\~\*\'\(\)\%\xa0-\xff]+)+ {
+~?(\/?[a-z0-9\.\-\_\!\~\'\(\)\%\xa0-\xff]+)+ {
 		yylval->name = g_strdup(yytext); return PATH;
 	}
 


### PR DESCRIPTION
Support for more valid URIs as per [https://www.man7.org/linux/man-pages/man7/uri.7.html](https://www.man7.org/linux/man-pages/man7/uri.7.html)

Unable to support escaped characters and `*` without more work.