### PR TITLE
sql: correctly parse 'inverse' operators

### DIFF
--- a/src/sql/parser.y
+++ b/src/sql/parser.y
@@ -151,6 +151,21 @@ sarg:
 				free($3);
 				}
 	| constant operator identifier {
+				switch($2) {
+					case MDB_GT:
+						$2 = MDB_LT;
+						break;
+					case MDB_LT:
+						$2 = MDB_GT;
+						break;
+					case MDB_GTEQ:
+						$2 = MDB_LTEQ;
+						break;
+					case MDB_LTEQ:
+						$2 = MDB_GTEQ;
+						break;
+				}
+
 	                        mdb_sql_add_sarg(parser_ctx->mdb, $3, $2, $1);
 				free($1);
 				free($3);


### PR DESCRIPTION
Pull request to fix issue #283 

This was the best solution I came up with, it simply passes the opposite operator, to make sure the ordering is correct