### PR TITLE
Add JET version for access 2013/2016/2019 to docs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -97,6 +97,9 @@ Offset 0x14 contains the Jet version of this database:
 - 0x01 for 4
 - 0x02 for 5
 - 0x03 for Access 2010
+- 0x04 for Access 2013
+- 0x05 for Access 2016
+- 0x06 for Access 2019
 
 This is used by the `mdb-ver` utility to determine the Jet version.
 


### PR DESCRIPTION
This PR updates the JET version list in `HACKING.md` to match the current implementation: https://github.com/mdbtools/mdbtools/blob/7d10a50faf3ff89fbb09252c218eb3ca92f5b19c/include/mdbtools.h#L78-L86


Thanks for the great library and research about access databases!