### PR TITLE
Migrate to g_memdup2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -219,6 +219,7 @@ if test "$enable_glib" = "yes"; then
         MDBTOOLS_CFLAGS="$MDBTOOLS_CFLAGS -DHAVE_GLIB=1"
         GLIB_CFLAGS="$GLIB_CFLAGS -DHAVE_GLIB=1"
         AC_SUBST(GLIB_PACKAGE)
+        AC_CHECK_LIB(glib-2.0, g_memdup2, [MDBTOOLS_CFLAGS="$MDBTOOLS_CFLAGS -DHAVE_G_MEMDUP2=1"])
     else
         enable_glib=no
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -216,10 +216,9 @@ if test "$enable_glib" = "yes"; then
     GLIB_PACKAGE=glib-2.0
     PKG_CHECK_MODULES([GLIB], [$GLIB_PACKAGE], HAVE_GLIB=true, HAVE_GLIB=false)
     if test "x$HAVE_GLIB" = "xtrue"; then
-        MDBTOOLS_CFLAGS="$MDBTOOLS_CFLAGS -DHAVE_GLIB=1"
         GLIB_CFLAGS="$GLIB_CFLAGS -DHAVE_GLIB=1"
         AC_SUBST(GLIB_PACKAGE)
-        AC_CHECK_LIB(glib-2.0, g_memdup2, [MDBTOOLS_CFLAGS="$MDBTOOLS_CFLAGS -DHAVE_G_MEMDUP2=1"])
+        AC_CHECK_LIB(glib-2.0, g_memdup2, [GLIB_CFLAGS="$GLIB_CFLAGS -DHAVE_G_MEMDUP2=1"])
     else
         enable_glib=no
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -217,8 +217,8 @@ if test "$enable_glib" = "yes"; then
     PKG_CHECK_MODULES([GLIB], [$GLIB_PACKAGE], HAVE_GLIB=true, HAVE_GLIB=false)
     if test "x$HAVE_GLIB" = "xtrue"; then
         GLIB_CFLAGS="$GLIB_CFLAGS -DHAVE_GLIB=1"
+        AC_CHECK_LIB($GLIB_PACKAGE, g_memdup2, [GLIB_CFLAGS="$GLIB_CFLAGS -DHAVE_G_MEMDUP2=1"])
         AC_SUBST(GLIB_PACKAGE)
-        AC_CHECK_LIB(glib-2.0, g_memdup2, [GLIB_CFLAGS="$GLIB_CFLAGS -DHAVE_G_MEMDUP2=1"])
     else
         enable_glib=no
     fi

--- a/include/mdbprivate.h
+++ b/include/mdbprivate.h
@@ -24,9 +24,8 @@
  * exported to calling programs.
  */
 
-#define _(String) (String)
-#define N_(String) String
-#define textdomain(Domain)
-#define bindtextdomain(Package, Directory)
+#ifndef HAVE_G_MEMDUP2
+#define g_memdup2 g_memdup
+#endif
 
 #endif

--- a/src/libmdb/file.c
+++ b/src/libmdb/file.c
@@ -19,6 +19,7 @@
 #include <inttypes.h>
 #include <stddef.h>
 #include "mdbtools.h"
+#include "mdbprivate.h"
 
 MdbFormatConstants MdbJet4Constants = {
 	.pg_size = 4096,
@@ -360,14 +361,14 @@ MdbHandle *mdb_clone_handle(MdbHandle *mdb)
 	MdbCatalogEntry *entry, *data;
 	unsigned int i;
 
-	newmdb = (MdbHandle *) g_memdup(mdb, sizeof(MdbHandle));
+	newmdb = (MdbHandle *) g_memdup2(mdb, sizeof(MdbHandle));
 
 	memset(&newmdb->catalog, 0, sizeof(MdbHandle) - offsetof(MdbHandle, catalog));
 
 	newmdb->catalog = g_ptr_array_new();
 	for (i=0;i<mdb->num_catalog;i++) {
 		entry = g_ptr_array_index(mdb->catalog,i);
-		data = g_memdup(entry,sizeof(MdbCatalogEntry));
+		data = g_memdup2(entry,sizeof(MdbCatalogEntry));
 		data->mdb = newmdb;
 		data->props = NULL;
 		g_ptr_array_add(newmdb->catalog, data);

--- a/src/libmdb/index.c
+++ b/src/libmdb/index.c
@@ -17,6 +17,7 @@
  */
 
 #include "mdbtools.h"
+#include "mdbprivate.h"
 #ifdef HAVE_LIBMSWSTR
 #include <mswstr/mswstr.h>
 #endif
@@ -524,7 +525,7 @@ mdb_index_test_sargs(MdbHandle *mdb, MdbIndex *idx, char *buf, int len)
 			col->idx_sarg_cache = g_ptr_array_new();
 			for (j=0;j<col->num_sargs;j++) {
 				sarg = g_ptr_array_index (col->sargs, j);
-				idx_sarg = g_memdup(sarg,sizeof(MdbSarg));
+				idx_sarg = g_memdup2(sarg,sizeof(MdbSarg));
 				//printf("calling mdb_index_cache_sarg\n");
 				mdb_index_cache_sarg(col, sarg, idx_sarg);
 				g_ptr_array_add(col->idx_sarg_cache, idx_sarg);

--- a/src/libmdb/sargs.c
+++ b/src/libmdb/sargs.c
@@ -29,6 +29,7 @@
 
 #include <time.h>
 #include "mdbtools.h"
+#include "mdbprivate.h"
 
 void
 mdb_sql_walk_tree(MdbSargNode *node, MdbSargTreeFunc func, gpointer data)
@@ -338,7 +339,7 @@ MdbSarg *sarg;
         if (!col->sargs) {
 		col->sargs = g_ptr_array_new();
 	}
-	sarg = g_memdup(in_sarg,sizeof(MdbSarg));
+	sarg = g_memdup2(in_sarg,sizeof(MdbSarg));
         g_ptr_array_add(col->sargs, sarg);
 	col->num_sargs++;
 

--- a/src/libmdb/table.c
+++ b/src/libmdb/table.c
@@ -17,6 +17,7 @@
  */
 
 #include "mdbtools.h"
+#include "mdbprivate.h"
 
 static gint mdb_col_comparer(MdbColumn **a, MdbColumn **b)
 {
@@ -91,7 +92,7 @@ MdbTableDef *mdb_read_table(MdbCatalogEntry *entry)
 		mdb_free_tabledef(table);
 		return NULL;
 	}
-	table->usage_map = g_memdup((char*)buf + row_start, table->map_sz);
+	table->usage_map = g_memdup2((char*)buf + row_start, table->map_sz);
 	if (mdb_get_option(MDB_DEBUG_USAGE)) 
 		mdb_buffer_dump(buf, row_start, table->map_sz);
 	mdb_debug(MDB_DEBUG_USAGE,"usage map found on page %ld row %d start %d len %d",
@@ -104,7 +105,7 @@ MdbTableDef *mdb_read_table(MdbCatalogEntry *entry)
 		mdb_free_tabledef(table);
 		return NULL;
 	}
-	table->free_usage_map = g_memdup((char*)buf + row_start, table->freemap_sz);
+	table->free_usage_map = g_memdup2((char*)buf + row_start, table->freemap_sz);
 	mdb_debug(MDB_DEBUG_USAGE,"free map found on page %ld row %d start %d len %d\n",
 		pg_row >> 8, pg_row & 0xff, row_start, table->freemap_sz);
 
@@ -207,7 +208,7 @@ read_pg_if_n(MdbHandle *mdb, void *buf, int *cur_pos, size_t len)
 
 void mdb_append_column(GPtrArray *columns, MdbColumn *in_col)
 {
-	g_ptr_array_add(columns, g_memdup(in_col,sizeof(MdbColumn)));
+	g_ptr_array_add(columns, g_memdup2(in_col,sizeof(MdbColumn)));
 }
 void mdb_free_columns(GPtrArray *columns)
 {

--- a/src/libmdb/worktable.c
+++ b/src/libmdb/worktable.c
@@ -17,6 +17,7 @@
  */
 
 #include "mdbtools.h"
+#include "mdbprivate.h"
 
 /*
  * Temp table routines.  These are currently used to generate mock results for
@@ -73,7 +74,7 @@ mdb_temp_table_add_col(MdbTableDef *table, MdbColumn *col)
 	col->col_num = table->num_cols;
 	if (!col->is_fixed)
 		col->var_col_num = table->num_var_cols++;
-	g_ptr_array_add(table->columns, g_memdup(col, sizeof(MdbColumn)));
+	g_ptr_array_add(table->columns, g_memdup2(col, sizeof(MdbColumn)));
 	table->num_cols++;
 }
 /*

--- a/src/util/mdb-ver.c
+++ b/src/util/mdb-ver.c
@@ -18,7 +18,6 @@
 
 #include "mdbtools.h"
 #include "mdbver.h"
-#include "mdbprivate.h"
 
 int
 main(int argc, char **argv)
@@ -58,7 +57,7 @@ main(int argc, char **argv)
 	}
 
 	if (!(mdb = mdb_open(argv[1], MDB_NOFLAGS))) {
-		fprintf(stderr,_("Error: unable to open file %s\n"), argv[1]);
+		fprintf(stderr,"Error: unable to open file %s\n", argv[1]);
 		exit(1);
 	}
 	switch(mdb->f->jet_version) {
@@ -84,7 +83,7 @@ main(int argc, char **argv)
 		printf("ACE17\n");
 		break;
 	default:
-		printf(_("unknown database version\n"));
+		printf("unknown database version\n");
 		break;
 	}
 	


### PR DESCRIPTION
With fakeglib and older versions of GLib, fall back to `g_memdup` with a `#define` inside mdbprivate.h.

Fixes #287