### PR TITLE
sql: allow double quoted (") database names

### DIFF
--- a/src/sql/mdbsql.c
+++ b/src/sql/mdbsql.c
@@ -217,9 +217,9 @@ MdbHandle *mdb_sql_open(MdbSQL *sql, char *db_name)
 	}
 #endif
 
-	sql->mdb = mdb_open(db_namep, MDB_NOFLAGS);
+	sql->mdb = mdb_open(db_name, MDB_NOFLAGS);
 	if ((!sql->mdb) && (!strstr(db_namep, ".mdb"))) {
-		char *tmpstr = (char *) g_strconcat(db_namep, ".mdb", NULL);
+		char *tmpstr = (char *) g_strconcat(db_name, ".mdb", NULL);
 		sql->mdb = mdb_open(tmpstr, MDB_NOFLAGS);
 		g_free(tmpstr);
 	}

--- a/src/sql/parser.y
+++ b/src/sql/parser.y
@@ -94,7 +94,7 @@ query:
 	SELECT top_clause column_list FROM table where_clause limit_clause {
 	                mdb_sql_select(parser_ctx->mdb);
 		}
-	|	CONNECT TO database { 
+	|	CONNECT TO database {
 	                mdb_sql_open(parser_ctx->mdb, $3); free($3);
 		}
 	|	DISCONNECT { 
@@ -212,7 +212,8 @@ constant:
 
 database:
 	PATH
-	|	NAME 
+	|	NAME
+	|	IDENT
 	;
 
 table:


### PR DESCRIPTION
- Allows IDENT to be used as a database
- The mdb_sql_open function needed to be changed to support spaces. Not 100% sure how it works but it has to pass the raw db_name and not the pointer to the subsequent functions. If passing db_namep, it only passes until the first space.