### PR TITLE
sql: allow double quoted (") database names (No space solution)

### DIFF
--- a/src/sql/parser.y
+++ b/src/sql/parser.y
@@ -212,7 +212,8 @@ constant:
 
 database:
 	PATH
-	|	NAME 
+	|	NAME
+	|	IDENT
 	;
 
 table:


### PR DESCRIPTION
#290 with only the quote issue fixed.