### PR TITLE
Update build.yml to upload release artifacts on tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: build
-on: [ push, pull_request ]
+on:
+  pull_request:
+  push:
+    tags:
+      - v*
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -38,6 +42,19 @@ jobs:
         run: pkg-config libmdbsql --exists
         env:
           PKG_CONFIG_PATH: .
+      - name: Packaging binary
+        shell: bash
+        run: |
+          cd `pwd`/installation/
+          tar czvf mdbtools-linux-${{ matrix.compiler }}-${{ matrix.glib }}.tar.gz *
+      - name: Releasing assets
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            installation/mdbtools-linux-${{ matrix.compiler }}-${{ matrix.glib }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   macos:
     runs-on: macos-latest
     strategy:
@@ -76,6 +93,19 @@ jobs:
         run: pkg-config libmdbsql --exists
         env:
           PKG_CONFIG_PATH: .
+      - name: Packaging binary
+        shell: bash
+        run: |
+          cd `pwd`/installation/
+          tar czvf mdbtools-macos-${{ matrix.compiler }}-${{ matrix.glib }}.tar.gz *
+      - name: Releasing assets
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            installation/mdbtools-macos-${{ matrix.compiler }}-${{ matrix.glib }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   macos-iodbc:
     runs-on: macos-latest
     strategy:
@@ -104,6 +134,19 @@ jobs:
         run: ./src/odbc/unittest
         env:
           MDBPATH: test/data
+      - name: Packaging binary
+        shell: bash
+        run: |
+          cd `pwd`/installation/
+          tar czvf mdbtools-macos-iodbc-${{ matrix.compiler }}-${{ matrix.glib }}.tar.gz *
+      - name: Releasing assets
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            installation/mdbtools-macos-iodbc-${{ matrix.compiler }}-${{ matrix.glib }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   windows:
     runs-on: windows-latest
     env:
@@ -122,3 +165,16 @@ jobs:
         run: C:\msys64\usr\bin\bash -c -l 'cd "$GITHUB_WORKSPACE" && bash -e -x ./test_script.sh'
       - name: SQL Test
         run: C:\msys64\usr\bin\bash -c -l 'cd "$GITHUB_WORKSPACE" && bash -e -x ./test_sql.sh'
+      - name: Packaging binary
+        shell: bash
+        run: |
+          cd `pwd`/installation/
+          tar czvf mdbtools-windows-${{ matrix.compiler }}-${{ matrix.glib }}.tar.gz *
+      - name: Releasing assets
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            installation/mdbtools-windows-${{ matrix.compiler }}-${{ matrix.glib }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Thanks for maintaining this effort!

For one of our [open source projects](https://github.com/NREL/ditto) we are interested shipping pre-compiled binaries of mdbtools to the user. It would be nice if the binaries that were compiled for testing were added to the github releases when a new tag is made. Thoughts?