### PR TITLE
Set _XOPEN_SOURCE to 600

### DIFF
--- a/src/sql/mdbsql.c
+++ b/src/sql/mdbsql.c
@@ -18,7 +18,7 @@
 
 #include <stdarg.h>
 #ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
 #endif
 #include "mdbsql.h"
 


### PR DESCRIPTION
Some platforms including RHEL need `_XOPEN_SOURCE` to be defined as a particular value. 600 seems to be a popular choice.

Fixes #301