### PR TITLE
Add backticks around table names in `mdb-query` output

### DIFF
--- a/src/sql/lexer.l
+++ b/src/sql/lexer.l
@@ -98,6 +98,8 @@ strptime	{ return STRPTIME; }
 		return IDENT;
 	}
 
+\[[^\]]+\] { yylval->name = g_strndup(yytext+1, yyleng-2); return NAME; }
+
 [a-z\xa0-\xff][a-z0-9_#@\xa0-\xff]*		{ yylval->name = g_strdup(yytext); return NAME; }
 
 '[^']*''  {

--- a/src/util/mdb-queries.c
+++ b/src/util/mdb-queries.c
@@ -185,7 +185,7 @@ int main (int argc, char **argv) {
 								if(strcmp(sql_tables,"") != 0) {
 									strcat(sql_tables,",");
 								}
-								sprintf(sql_tables+strlen(sql_tables),"`%s`",name1);
+								sprintf(sql_tables+strlen(sql_tables),"[%s]",name1);
 								break;
 							case 6:		// column name
 								if(strcmp(sql_columns,"") == 0) {

--- a/src/util/mdb-queries.c
+++ b/src/util/mdb-queries.c
@@ -182,12 +182,10 @@ int main (int argc, char **argv) {
 								}
 								break;
 							case 5:		// table name
-								if(strcmp(sql_tables,"") == 0) {
-									strcpy(sql_tables,name1);
-								} else {
+								if(strcmp(sql_tables,"") != 0) {
 									strcat(sql_tables,",");
-									strcat(sql_tables,name1);
 								}
+								sprintf(sql_tables+strlen(sql_tables),"`%s`",name1);
 								break;
 							case 6:		// column name
 								if(strcmp(sql_columns,"") == 0) {


### PR DESCRIPTION
When table names in a schema have whitespace in them, `mdb-queries` emits invalid syntax, like
```sql
SELECT foo FROM some table,another
```

This PR changes the `mdb-queries` output to throw brackets around table names.  It doesn't bother to check for whitespace to see if the table name actually needs the brackets.  It just includes them unconditionally.  So, for example:
```sql
SELECT foo FROM [some table],[another]
```