### PR TITLE
Fix -Werror=array-bounds compile error in src/odbc/odbc.c

### DIFF
--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -979,12 +979,13 @@ SQLRETURN SQL_API SQLErrorW(
 	result = SQLError(henv, hdbc, hstmt, szSqlState8, pfNativeError, szErrorMsg8, 3*cbErrorMsgMax+1, &pcbErrorMsg8);
 	if (result == SQL_SUCCESS) {
         struct _hdbc *dbc = hstmt ? ((struct _hstmt *)hstmt)->hdbc : hdbc;
-		size_t l=6, z=6*sizeof(SQLWCHAR);
-		ascii2unicode(dbc, (char*)szSqlState8, &l, (char*)szSqlState, &z);
-		l = cbErrorMsgMax;
-		ascii2unicode(dbc, (char*)szErrorMsg8, (size_t*)&pcbErrorMsg8, (char*)szErrorMsg, &l);
+		size_t lin=6, lout=6*sizeof(SQLWCHAR);
+		ascii2unicode(dbc, (char*)szSqlState8, &lin, (char*)szSqlState, &lout);
+		lin = pcbErrorMsg8;
+		lout = cbErrorMsgMax;
+		ascii2unicode(dbc, (char*)szErrorMsg8, &lin, (char*)szErrorMsg, &lout);
 		if (pcbErrorMsg)
-			*pcbErrorMsg = l;
+			*pcbErrorMsg = lout;
 	}
 	return result;
 }


### PR DESCRIPTION
Use a local variable instead of casting the address of a SQLSMALLINT to a (size_t *). sizeof(SQLSMALLINT) < sizeof(size_t) so gcc is rightfully giving the following errors when building on Fedora 34:

```
/usr/include/sqlucode.h: In function 'SQLErrorW':
odbc.c:130:20: error: array subscript 'size_t[0]' is partly outside array bounds of 'SQLSMALLINT[1]' [-Werror=array-bounds]
  130 |         size_t lin=*_lin, lout=*_lout;
      |                    ^~~~~
odbc.c:974:21: note: while referencing 'pcbErrorMsg8'
  974 |         SQLSMALLINT pcbErrorMsg8;
      |                     ^~~~~~~~~~~~
odbc.c:133:15: error: array subscript 'size_t[0]' is partly outside array bounds of 'SQLSMALLINT[1]' [-Werror=array-bounds]
  133 |         *_lin -= lin;
      |               ^~
odbc.c:974:21: note: while referencing 'pcbErrorMsg8'
  974 |         SQLSMALLINT pcbErrorMsg8;
      |                     ^~~~~~~~~~~~
odbc.c:133:15: error: array subscript 'size_t[0]' is partly outside array bounds of 'SQLSMALLINT[1]' [-Werror=array-bounds]
  133 |         *_lin -= lin;
      |         ~~~~~~^~~~~~
odbc.c:974:21: note: while referencing 'pcbErrorMsg8'
  974 |         SQLSMALLINT pcbErrorMsg8;
      |                     ^~~~~~~~~~~~
cc1: all warnings being treated as errors
```