### PR TITLE
sql: Properly handle arbitrary parentheses placements in PATH breaking SELECT functions

### DIFF
--- a/src/sql/lexer.l
+++ b/src/sql/lexer.l
@@ -74,8 +74,8 @@ like		{ return LIKE; }
 limit		{ return LIMIT; }
 top		{ return TOP; }
 percent		{ return PERCENT; }
-count*		{ return COUNT; }
-strptime*	{ return STRPTIME; }
+count\(		{ return COUNT; }
+strptime\(	{ return STRPTIME; }
 [ \t\r]	;
 
 \"[^"]*\"\"  {
@@ -114,7 +114,14 @@ strptime*	{ return STRPTIME; }
 (-?[0-9]+|(-?[0-9]*\.[0-9]+)(e[-+]?[0-9]+)?) {
 		yylval->name = g_strdup(yytext); return NUMBER;
 	}
-~?(\/?[a-z0-9\.\-\_\!\~\'\%\xa0-\xff]+)+ {
+~?(\/?[a-z0-9\.\-\_\!\~\'\(\)\%\xa0-\xff]+)+ {
+        if (yytext[0] == ')' && strlen(yytext) == 1) {
+            return CLOSING;
+        }
+
+        if (yytext[0] == '(' && strlen(yytext) == 1) {
+            return OPENING;
+        }
 		yylval->name = g_strdup(yytext); return PATH;
 	}
 

--- a/src/sql/lexer.l
+++ b/src/sql/lexer.l
@@ -74,8 +74,8 @@ like		{ return LIKE; }
 limit		{ return LIMIT; }
 top		{ return TOP; }
 percent		{ return PERCENT; }
-count		{ return COUNT; }
-strptime	{ return STRPTIME; }
+count*		{ return COUNT; }
+strptime*	{ return STRPTIME; }
 [ \t\r]	;
 
 \"[^"]*\"\"  {
@@ -114,7 +114,7 @@ strptime	{ return STRPTIME; }
 (-?[0-9]+|(-?[0-9]*\.[0-9]+)(e[-+]?[0-9]+)?) {
 		yylval->name = g_strdup(yytext); return NUMBER;
 	}
-~?(\/?[a-z0-9\.\-\_\!\~\'\(\)\%\xa0-\xff]+)+ {
+~?(\/?[a-z0-9\.\-\_\!\~\'\%\xa0-\xff]+)+ {
 		yylval->name = g_strdup(yytext); return PATH;
 	}
 

--- a/src/sql/parser.y
+++ b/src/sql/parser.y
@@ -60,7 +60,7 @@ typedef struct sql_context
 
 %start stmt
 
-%token <name> IDENT NAME PATH STRING NUMBER
+%token <name> IDENT NAME PATH STRING NUMBER OPENING CLOSING
 %token SELECT FROM WHERE CONNECT DISCONNECT TO LIST TABLES AND OR NOT LIMIT COUNT STRPTIME
 %token DESCRIBE TABLE TOP PERCENT
 %token LTEQ GTEQ LIKE IS NUL
@@ -138,7 +138,7 @@ limit_clause:
 
 sarg_list:
 	sarg 
-	| '(' sarg_list ')'
+	| OPENING sarg_list CLOSING
 	| NOT sarg_list { mdb_sql_add_not(parser_ctx->mdb); }
 	| sarg_list OR sarg_list { mdb_sql_add_or(parser_ctx->mdb); }
 	| sarg_list AND sarg_list { mdb_sql_add_and(parser_ctx->mdb); }
@@ -201,10 +201,10 @@ nulloperator:
 	;
 
 constant:
-	STRPTIME '(' constant ',' constant ')' { 
-	        $$ = mdb_sql_strptime(parser_ctx->mdb, $3, $5);
-		free($3);
-		free($5);
+	STRPTIME constant ',' constant CLOSING {
+	        $$ = mdb_sql_strptime(parser_ctx->mdb, $2, $4);
+		free($2);
+		free($4);
 	}
 	| NUMBER { $$ = $1; }
 	| STRING { $$ = $1; }
@@ -221,7 +221,7 @@ table:
 	;
 
 column_list:
-	COUNT '(' '*' ')'	{ mdb_sql_sel_count(parser_ctx->mdb); }
+	COUNT '*' CLOSING	{ mdb_sql_sel_count(parser_ctx->mdb); }
 	| '*'	{ mdb_sql_all_columns(parser_ctx->mdb); }
 	|	column  
 	|	column ',' column_list 


### PR DESCRIPTION
Fixes #318 and attempts to mitigate future issues.

Lexer was reading functions such as `COUNT(*)` as a PATH, these changes make any functions defined in the lexer to specify an `(`, and changes the parser to use FUNC (...) CLOSING.

e.g. `COUNT(*)` is `count\( { return COUNT}` and `COUNT '*' CLOSING {...}`

In order to stop issues with sarg_list if a PATH is `(`, it is lexed as an OPENING.

This was the cleanest method of implementing the fix I could find.