### PR TITLE
Fix gcc-11 error "directive argument is null"

### DIFF
--- a/src/libmdb/catalog.c
+++ b/src/libmdb/catalog.c
@@ -193,7 +193,7 @@ mdb_dump_catalog(MdbHandle *mdb, int obj_type)
                 entry = g_ptr_array_index(mdb->catalog,i);
 		if (obj_type==MDB_ANY || entry->object_type==obj_type) {
 			printf("Type: %-12s Name: %-48s Page: %06lx\n",
-			mdb_get_objtype_string(entry->object_type),
+			mdb_get_objtype_string(entry->object_type) ?: "Unknown",
 			entry->object_name,
 			entry->table_pg);
 		}


### PR DESCRIPTION
mdbtools triggered
In function ‘printf’,
    inlined from ‘mdb_dump_catalog’ at catalog.c:195:4:
/usr/include/powerpc64le-linux-gnu/bits/stdio2.h:112:10:
error: ‘%-12s’ directive argument is null [-Werror=format-overflow=]
  112 |   return __printf_chk (__USE_FORTIFY_LEVEL - 1, __fmt, __va_arg_pack ());

This is due to mdb_get_objtype_string potentially returning NULL
which isn't allowed anymore as it would cause a segfault on the latter
print.

Fixes: #352

This is the revised version based on the feedback about preferred style in https://github.com/mdbtools/mdbtools/issues/352#issuecomment-930190035

I have successfully test-built it across architectures in https://launchpad.net/~ci-train-ppa-service/+archive/ubuntu/4675/+packages