### PR TITLE
Fix gcc-11 error "directive argument is null"

### DIFF
--- a/src/libmdb/catalog.c
+++ b/src/libmdb/catalog.c
@@ -193,7 +193,7 @@ mdb_dump_catalog(MdbHandle *mdb, int obj_type)
                 entry = g_ptr_array_index(mdb->catalog,i);
 		if (obj_type==MDB_ANY || entry->object_type==obj_type) {
 			printf("Type: %-12s Name: %-48s Page: %06lx\n",
-			mdb_get_objtype_string(entry->object_type),
+			mdb_get_objtype_string(entry->object_type) ?: "Unknown",
 			entry->object_name,
 			entry->table_pg);
 		}


### PR DESCRIPTION
This PR only exists if you want to merge/backport this to the 0.9.4 release branches as well.
It is a sibling to #353 
Feel free to close/ignore if you prefer to e.g. cherry-pick from -dev.