### PR TITLE
Always check mdb_read_table() return value

### DIFF
--- a/src/libmdb/backend.c
+++ b/src/libmdb/backend.c
@@ -872,6 +872,10 @@ generate_table_schema(FILE *outfile, MdbCatalogEntry *entry, char *dbnamespace, 
 	fprintf (outfile, " (\n");
 
 	table = mdb_read_table (entry);
+	if (!table) {
+		fprintf(stderr, "Error: Table %s does not exist\n", entry->object_name);
+		return;
+	}
 
 	/* get the columns */
 	mdb_read_columns(table);

--- a/src/libmdb/table.c
+++ b/src/libmdb/table.c
@@ -361,6 +361,9 @@ unsigned int i, bitn;
 guint32 pgnum;
 
 	table = mdb_read_table(entry);
+	if (!table)
+		return;
+
 	fprintf(stdout,"definition page     = %lu\n",entry->table_pg);
 	fprintf(stdout,"number of datarows  = %d\n",table->num_rows);
 	fprintf(stdout,"number of columns   = %d\n",table->num_cols);

--- a/src/util/mdb-header.c
+++ b/src/util/mdb-header.c
@@ -92,6 +92,11 @@ FILE *cfile;
 			entry->object_name, entry->object_name);
 	       fprintf (cfile, "\tfprintf (stdout, \"**************** %s ****************\\n\");\n", entry->object_name);
 	       table = mdb_read_table (entry);
+	       if (!table) {
+			fprintf(stderr, "Error: Table %s does not exist in this database.\n", entry->object_name);
+			/* Don't bother clean up memory before exit */
+			exit(1);
+	       }
 
 	       /* get the columns */
 	       mdb_read_columns (table);


### PR DESCRIPTION
A couple of places were missing NULL return value checks for mdb_read_table()'s return value. Add these.

This fixes a NULL pointer deref while running ./test_script.sh on the test mdb file from oss-fuzz/35972 .

Note this does NOT fix the original problem reported in oss-fuzz/35972 which reports a "Dynamic-stack-buffer-overflow WRITE 16" issue, which I've been unable to reproduce.

Note the NULL pointer deref I saw is the one from  src/libmdb/backend.c, but while at it I've audited the entire code base for similar cases.