### PR TITLE
Changed mapping of MDB_DOUBLE for MySQL from float to double

### DIFF
--- a/src/libmdb/backend.c
+++ b/src/libmdb/backend.c
@@ -111,7 +111,7 @@ static const MdbBackendType mdb_mysql_types[] = {
     [MDB_LONGINT] = { .name = "int" },
     [MDB_MONEY] = { .name = "float" },
     [MDB_FLOAT] = { .name = "float" },
-    [MDB_DOUBLE] = { .name = "float" },
+    [MDB_DOUBLE] = { .name = "double" },
     [MDB_DATETIME] = { .name = "datetime" },
     [MDB_BINARY] = { .name = "blob" },
     [MDB_TEXT] = { .name = "varchar", .needs_char_length = 1 },


### PR DESCRIPTION
MDB_DOUBLE is a 64-bit double precision value and in MySQL this should be DOUBLE instead of FLOAT (https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html)