### PR TITLE
Fix program 'mdb-import' not being installed

### DIFF
--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -1,12 +1,12 @@
 AUTOMAKE_OPTIONS = subdir-objects
 SUBDIRS = bash-completion
-bin_PROGRAMS	=	mdb-export mdb-array mdb-schema mdb-tables mdb-parsecsv mdb-header mdb-ver mdb-prop mdb-count mdb-queries mdb-json
-noinst_PROGRAMS = mdb-import prtable prcat prdata prkkd prdump prole updrow prindex
+bin_PROGRAMS	=	mdb-export mdb-array mdb-schema mdb-tables mdb-parsecsv mdb-header mdb-ver mdb-prop mdb-count mdb-queries mdb-json mdb-import
+noinst_PROGRAMS = prtable prcat prdata prkkd prdump prole updrow prindex
 noinst_HEADERS = base64.h
 LIBS	=	$(GLIB_LIBS) @LIBS@
 DEFS = @DEFS@ -DLOCALEDIR=\"$(localedir)\"
 AM_CFLAGS	=	-I$(top_srcdir)/include $(GLIB_CFLAGS) -Wsign-compare
-LDADD	=	../libmdb/libmdb.la 
+LDADD	=	../libmdb/libmdb.la
 if SQL
 bin_PROGRAMS += mdb-sql
 mdb_sql_LDADD = ../libmdb/libmdb.la ../sql/libmdbsql.la $(LIBREADLINE)


### PR DESCRIPTION
There was a man page `mdb-import.1` getting installed but no bin `mdb-import`.

Seems like a useful program, so let's target it with `make install`.