### PR TITLE
Fix wrongly installed mdb-sql completion script

### DIFF
--- a/src/util/bash-completion/Makefile.am
+++ b/src/util/bash-completion/Makefile.am
@@ -1,4 +1,7 @@
 if ENABLE_BASH_COMPLETION
 bashcompletiondir = $(BASH_COMPLETION_DIR)
-dist_bashcompletion_DATA = mdb-count mdb-export mdb-hexdump mdb-import mdb-json mdb-parsecsv mdb-prop mdb-queries mdb-schema mdb-sql mdb-tables mdb-ver
+dist_bashcompletion_DATA = mdb-count mdb-export mdb-hexdump mdb-import mdb-json mdb-parsecsv mdb-prop mdb-queries mdb-schema mdb-tables mdb-ver
+if SQL
+  dist_bashcompletion_DATA += mdb-sql
+endif
 endif


### PR DESCRIPTION
Gate it behind the same conditional that the `mdb-sql` program is gated behind.