### PR TITLE
Fix ODBC_LIBS for unixODBC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ AC_ARG_WITH(unixodbc,
 if test "$with_unixodbc"; then
 	HAVE_ODBC=true
 	ODBC_CFLAGS="-I$with_unixodbc/include"
-	ODBC_LIBS="-L$with_unixodbc/$libdir"
+	ODBC_LIBS="-L$with_unixodbc/lib"
 
 	dnl SIZEOF_LONG_INT and HAVE_LONG_LONG are required by some versions of unixODBC
 	dnl https://github.com/lurcher/unixODBC/issues/40


### PR DESCRIPTION
Using `$libdir` doesn't work and produces an error when configuring with ` ./configure --with-unixodbc=$(brew --prefix)`

> configure:21209: gcc -o conftest -g -O2 -Wall -Werror   -L/opt/homebrew/${exec_prefix}/lib conftest.c -lodbcinst   >&5
> ld: warning: directory not found for option '-L/opt/homebrew/${exec_prefix}/lib'
> ld: library not found for -lodbcinst
> clang: error: linker command failed with exit code 1 (use -v to see invocation)

Note that `warning: directory not found for option '-L/.../${exec_prefix}/lib'` is always emitted but if unixodbc is installed in `/usr/local/lib` linking would still work.