### PR TITLE
Fixed truncating 64bit NULL return values

### DIFF
--- a/src/odbc/mdbodbc.h
+++ b/src/odbc/mdbodbc.h
@@ -72,8 +72,8 @@ struct _hstmt {
 struct _sql_bind_info {
 	int column_number;
 	int column_bindtype; /* type/conversion required */
-	int column_bindlen; /* size of varaddr buffer */
-	int *column_lenbind; /* where to store length of varaddr used */
+	SQLLEN column_bindlen; /* size of varaddr buffer */
+	SQLLEN *column_lenbind; /* where to store length of varaddr used */
 	char *varaddr;
 	struct _sql_bind_info *next;
 };

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -513,7 +513,7 @@ SQLRETURN SQL_API SQLBindCol(
 	/* if this is a repeat */
 	if (cur) {
 		cur->column_bindtype = fCType;
-   		cur->column_lenbind = (int *)pcbValue;
+   		cur->column_lenbind = pcbValue;
    		cur->column_bindlen = cbValueMax;
    		cur->varaddr = (char *) rgbValue;
 	} else {
@@ -522,7 +522,7 @@ SQLRETURN SQL_API SQLBindCol(
 		newitem->column_number = icol;
 		newitem->column_bindtype = fCType;
    		newitem->column_bindlen = cbValueMax;
-   		newitem->column_lenbind = (int *)pcbValue;
+   		newitem->column_lenbind = pcbValue;
    		newitem->varaddr = (char *) rgbValue;
 		/* if there's no head yet */
 		if (! stmt->bind_head) {


### PR DESCRIPTION
This fixes issue here https://github.com/mdbtools/mdbtools/issues/312

It breaks on 64bit machines in cases where SQLFetch() calls SQLGetData() and latter functions sets `pcbValue = SQL_NULL_DATA NULL`.

`SQLLEN pcbValue` is 64bit integer and it gets stored to `*_sql_bind_info::column_lenbind` which is pointer to 32bit int, but really it points to 64bit int of type `SQLLEN`

This is possibly also solving more issues with wrong 64bit integers being returned from tables.