### PR TITLE
Fix invalid byte sequence error when running test_script.sh in some cases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Make
         run: make
       - name: CLI tests
-        run: bash -e -x ./test_script.sh
+        run: ./test_script.sh
       - name: SQL tests
         run: bash -e -x ./test_sql.sh
       - name: ODBC tests
@@ -63,7 +63,7 @@ jobs:
       - name: Make
         run: make
       - name: CLI tests
-        run: bash -e -x ./test_script.sh
+        run: ./test_script.sh
       - name: SQL tests
         run: bash -e -x ./test_sql.sh
       - name: ODBC tests
@@ -138,6 +138,6 @@ jobs:
       - name: Make
         run: make
       - name: Test
-        run: bash -e -x ./test_script.sh
+        run: ./test_script.sh
       - name: SQL Test
         run: bash -e -x ./test_sql.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: build
 on: [ push, pull_request ]
+env:
+  TEST_DATA_URL: https://github.com/mdbtools/mdbtestdata/archive/refs/heads/master.tar.gz
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -14,7 +16,10 @@ jobs:
         run: sudo apt install gettext
       - uses: actions/checkout@v2
       - name: Fetch test data
-        run: git clone https://github.com/mdbtools/mdbtestdata.git test
+        run: |
+          rm -rf test
+          mkdir test
+          curl -sSLf "$TEST_DATA_URL" | tar xz --strip-components=1 -C test
       - name: Autoconf
         run: autoreconf -i -f
       - name: Configure
@@ -52,7 +57,10 @@ jobs:
         run: brew install bison gawk automake
       - uses: actions/checkout@v2
       - name: Fetch test data
-        run: git clone https://github.com/mdbtools/mdbtestdata.git test
+        run: |
+          rm -rf test
+          mkdir test
+          curl -sSLf "$TEST_DATA_URL" | tar xz --strip-components=1 -C test
       - name: Autoconf
         run: autoreconf -i -f
       - name: Configure
@@ -94,7 +102,10 @@ jobs:
         run: echo /usr/local/opt/libiodbc/bin >> $GITHUB_PATH
       - uses: actions/checkout@v2
       - name: Fetch test data
-        run: git clone https://github.com/mdbtools/mdbtestdata.git test
+        run: |
+          rm -rf test
+          mkdir test
+          curl -sSLf "$TEST_DATA_URL" | tar xz --strip-components=1 -C test
       - name: Autoconf
         run: autoreconf -i -f
       - name: Configure
@@ -130,7 +141,10 @@ jobs:
             glib2-devel
       - uses: actions/checkout@v2
       - name: Check out test data
-        run: git clone https://github.com/mdbtools/mdbtestdata.git test
+        run: |
+          rm -rf test
+          mkdir test
+          curl -sSLf "$TEST_DATA_URL" | tar xz --strip-components=1 -C test
       - name: Autoconf
         run: autoreconf -i -f
       - name: Configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
             git
             glib2-devel
       - uses: actions/checkout@v2
-      - name: Check out test data
+      - name: Fetch test data
         run: |
           rm -rf test
           mkdir test

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ m4/
 config.log
 config.status
 configure
+/configure~
 Makefile.in
 Makefile
 doc/*.1
@@ -54,10 +55,9 @@ src/util/prkkd
 src/util/prole
 src/util/prtable
 src/util/updrow
-
+/test/
 ## apidocs docs related
 public/
 .sass-cache/
 *.css.map
 temp-man-pages/
-

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -o errexit
 set -x

--- a/test_script.sh
+++ b/test_script.sh
@@ -21,3 +21,5 @@ LANG=C.UTF-8
 ./src/util/mdb-ver test/data/ASampleDatabase.accdb
 ./src/util/mdb-ver test/data/nwind.mdb
 ./src/util/mdb-queries test/data/ASampleDatabase.accdb qryCostsSummedByOwner
+
+printf -- '\n\n%s Passed.\n' "$0"

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit
+set -x
+
 # Simple test script; run after performing
 # git clone https://github.com/mdbtools/mdbtestdata.git test
 ./src/util/mdb-json test/data/ASampleDatabase.accdb "Asset Items"

--- a/test_script.sh
+++ b/test_script.sh
@@ -3,6 +3,8 @@
 set -o errexit
 set -x
 
+LANG=C.UTF-8
+
 # Simple test script; run after performing
 # git clone https://github.com/mdbtools/mdbtestdata.git test
 ./src/util/mdb-json test/data/ASampleDatabase.accdb "Asset Items"


### PR DESCRIPTION
In some cases, running test_script.sh fails with this error:

```
argument parsing failed: Invalid byte sequence in conversion input
```

... plus some other minor changes 😉 (see each commit message)