### PR TITLE
Make test_script.sh less verbose (configurable)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Make
         run: make
       - name: CLI tests
-        run: ./test_script.sh
+        run: ./test_script.sh --github
       - name: SQL tests
         run: bash -e -x ./test_sql.sh
       - name: ODBC tests
@@ -71,7 +71,7 @@ jobs:
       - name: Make
         run: make
       - name: CLI tests
-        run: ./test_script.sh
+        run: ./test_script.sh --github
       - name: SQL tests
         run: bash -e -x ./test_sql.sh
       - name: ODBC tests
@@ -152,6 +152,6 @@ jobs:
       - name: Make
         run: make
       - name: Test
-        run: ./test_script.sh
+        run: ./test_script.sh --github
       - name: SQL Test
         run: bash -e -x ./test_sql.sh

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ src/util/prole
 src/util/prtable
 src/util/updrow
 /test/
+/.vscode/
 ## apidocs docs related
 public/
 .sass-cache/

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,25 +1,131 @@
 #!/bin/sh
 
-set -o errexit
-set -x
-
-LANG=C.UTF-8
-
 # Simple test script; run after performing
 # git clone https://github.com/mdbtools/mdbtestdata.git test
-./src/util/mdb-json test/data/ASampleDatabase.accdb "Asset Items"
-./src/util/mdb-json test/data/nwind.mdb "Umsätze"
-./src/util/mdb-count test/data/ASampleDatabase.accdb "Asset Items"
-./src/util/mdb-count test/data/nwind.mdb "Umsätze"
-./src/util/mdb-prop test/data/ASampleDatabase.accdb "Asset Items"
-./src/util/mdb-prop test/data/nwind.mdb "Umsätze"
-./src/util/mdb-schema test/data/ASampleDatabase.accdb
-./src/util/mdb-schema test/data/nwind.mdb
-./src/util/mdb-schema test/data/nwind.mdb -T "Umsätze" postgres
-./src/util/mdb-tables test/data/ASampleDatabase.accdb
-./src/util/mdb-tables test/data/nwind.mdb
-./src/util/mdb-ver test/data/ASampleDatabase.accdb
-./src/util/mdb-ver test/data/nwind.mdb
-./src/util/mdb-queries test/data/ASampleDatabase.accdb qryCostsSummedByOwner
 
-printf -- '\n\n%s Passed.\n' "$0"
+set -o errexit
+set -o nounset
+
+LANG=C.UTF-8
+CDPATH= cd -- "$(dirname -- "$0")"
+
+parseArgs() {
+	MT_OUTPUT_KIND=verbose
+	while :; do
+		if test $# -lt 1; then
+			break
+		fi
+		case "$1" in
+			-q | --quiet)
+				MT_OUTPUT_KIND=quiet
+				;;
+			-g | --github)
+				MT_OUTPUT_KIND=github
+				;;
+			-h | --help)
+				printf 'Syntax:\n%s [-q|--quiet|-g|--github] [-h|--help]\n' "$0"
+				exit 0
+				;;
+			*)
+				printf 'Unrecognized option: "%s"\n' "$1"
+				exit 1
+				;;
+		esac
+		shift
+	done
+}
+
+testCommand() {
+	testCommand_name="$1"
+	shift
+	case $MT_OUTPUT_KIND in
+		verbose)
+			printf '# Running %s (%s)\n' "$testCommand_name" "$*"
+			if "./src/util/$testCommand_name" "$@"; then
+				return 0
+			fi
+			return 1
+			;;
+		quiet)
+			printf 'Testing %s (%s)... ' "$testCommand_name" "$*"
+			if "./src/util/$testCommand_name" "$@" >/dev/null; then
+				printf 'passed.\n'
+				return 0
+			fi
+			return 1
+			;;
+		github)
+			testCommand_tempFile="$(mktemp)"
+			printf 'Testing %s (%s)... ' "$testCommand_name" "$*"
+			if "./src/util/$testCommand_name" "$@" 2>&1 >"$testCommand_tempFile"; then
+				printf 'passed.\n'
+				testCommand_rc=0
+			else
+				printf 'failed.\n'
+				testCommand_rc=1
+			fi
+			echo '::group::Output'
+			cat "$testCommand_tempFile"
+			echo '::endgroup::'
+			unlink "$testCommand_tempFile"
+			return $testCommand_rc
+			;;
+		*)
+			printf 'Unrecognized MT_OUTPUT_KIND (%s)\n' "$MT_OUTPUT_KIND"
+			exit 1
+			;;
+	esac
+}
+
+parseArgs "$@"
+
+rc=0
+if ! testCommand mdb-json test/data/ASampleDatabase.accdb "Asset Items"; then
+	rc=1
+fi
+if ! testCommand mdb-json test/data/nwind.mdb "Umsätze"; then
+	rc=1
+fi
+if ! testCommand mdb-count test/data/ASampleDatabase.accdb "Asset Items"; then
+	rc=1
+fi
+if ! testCommand mdb-count test/data/nwind.mdb "Umsätze"; then
+	rc=1
+fi
+if ! testCommand mdb-prop test/data/ASampleDatabase.accdb "Asset Items"; then
+	rc=1
+fi
+if ! testCommand mdb-prop test/data/nwind.mdb "Umsätze"; then
+	rc=1
+fi
+if ! testCommand mdb-schema test/data/ASampleDatabase.accdb; then
+	rc=1
+fi
+if ! testCommand mdb-schema test/data/nwind.mdb; then
+	rc=1
+fi
+if ! testCommand mdb-schema test/data/nwind.mdb -T "Umsätze" postgres; then
+	rc=1
+fi
+if ! testCommand mdb-tables test/data/ASampleDatabase.accdb; then
+	rc=1
+fi
+if ! testCommand mdb-tables test/data/nwind.mdb; then
+	rc=1
+fi
+if ! testCommand mdb-ver test/data/ASampleDatabase.accdb; then
+	rc=1
+fi
+if ! testCommand mdb-ver test/data/nwind.mdb; then
+	rc=1
+fi
+if ! testCommand mdb-queries test/data/ASampleDatabase.accdb qryCostsSummedByOwner; then
+	rc=1
+fi
+
+if [ $rc = 0 ]; then
+	printf -- '\n%s passed.\n' "$0"
+else
+	printf -- '\n%s failed!\n' "$0"
+fi
+exit $rc


### PR DESCRIPTION
The output of test_script.sh is very long, and that may hide issues.

What about adding a way to control its output?

Invoking it with:
- by default, we have the current behavior (print the output of commands)
- `-q` (or `--quitet`) suppresses the output of commands
- `-g` (or `--github`) prints the outout of commands in [sections](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines), which makes the GitHub Actions output much more readable
- `-h` (or `--help`) prints the list of supported options
