### PR TITLE
Fix a minor error in the mdb-json man page

### DIFF
--- a/doc/mdb-json.txt
+++ b/doc/mdb-json.txt
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
   mdb-json is a utility program distributed with MDB Tools. 
 
-  It produces a CSV (comma separated value) output for the given table. Such output is suitable for importation into databases or spreadsheets.
+  It produces JSON output for the given table. Such output is suitable for parsing in a variety of languages.
 
 OPTIONS
   -D, --date-format fmt     Set the date format (see strftime(3) for details).


### PR DESCRIPTION
Very minor documentation bug: Line 12 of doc/mdb-json.txt says:

" It produces a CSV (comma separated value) output for the given table. Such output is suitable for importation into databases or spreadsheets."

Not true. It produces JSON format, suitable for parsing into objects in a variety of languages.

Apparently the line was copied from mdb-export.txt and never updated.

Thanks for mdbtools!