### PR TITLE
Move includes out of extern "C" block

### DIFF
--- a/include/mdbtools.h.in
+++ b/include/mdbtools.h.in
@@ -21,9 +21,6 @@
 #define MDBTOOLS_H_HAVE_ICONV_H @HAVE_ICONV_H@
 #define MDBTOOLS_H_HAVE_XLOCALE_H @HAVE_XLOCALE_H@
 
-#ifdef __cplusplus
-  extern "C" {
-#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -46,6 +43,10 @@
 
 #ifdef _WIN32
 #include <io.h>
+#endif
+
+#ifdef __cplusplus
+  extern "C" {
 #endif
 
 /** \addtogroup mdbtools


### PR DESCRIPTION
"mbdtools.h" couldn't be included from C++ files, because the "glib.h" include is in the extern "C" block. The latter includes C++ headers for C++ source files, which define templates. These don't work with extern "C" linkage and the compilation falls apart with numerous errors.

To fix this problem, move the includes out of the extern "C" block.