### PR TITLE
Add missing `& offset_mask` for calculating `offset_stop of memo` 

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -259,7 +259,7 @@ offset_start of memo = (int16*) LVAL_page[offset_num_rows + (row_id * 2) + 2]
 if (row_id = 0)
      offset_stop of memo = 2048(jet3) or 4096(jet4)
 else
-     offset_stop of memo = (int16*) LVAL_page[offset_num_row + (row_id * 2)]
+     offset_stop of memo = (int16*) LVAL_page[offset_num_row + (row_id * 2)] & offset_mask // offset_mask = 0x1fff
 ```
 
 The length (partial if type 2) for the memo is:


### PR DESCRIPTION
According to https://github.com/mdbtools/mdbtools/blob/2b2ef525c89cf0b67f690b41b3e40b8f181f1b8e/src/libmdb/data.c#L175

Add missing `& offset_mask` for calculating `offset_stop of memo` in HACKING.md