### PR TITLE
fix build failures with gcc-14

### DIFF
--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -2058,7 +2058,7 @@ static int _odbc_fix_literals(struct _hstmt *stmt)
 	char tmp[4096];
 	char *s, *d, *p;
 	int i, quoted = 0, find_end = 0;
-	char quote_char;
+	char quote_char = '\0';
 
 	s=stmt->query;
 	d=tmp;

--- a/src/util/mdb-sql.c
+++ b/src/util/mdb-sql.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 
 #ifdef HAVE_LIBREADLINE
 #  if defined(HAVE_READLINE_READLINE_H)
@@ -322,7 +323,11 @@ main(int argc, char **argv)
 	char prompt[20];
 	int line = 0;
 	char *mybuf;
+#ifdef __arm__
+	uint64_t bufsz;
+#else
 	unsigned int bufsz;
+#endif
 	MdbSQL *sql;
 	FILE *in = NULL, *out = NULL;
 	char *filename_in=NULL, *filename_out=NULL;


### PR DESCRIPTION
The builds on riscv64,ppc64el and s390x are failing with the error:

```
odbc.c: In function '_odbc_fix_literals.isra':
odbc.c:1998:35: error: 'quote_char' may be used uninitialized [-Werror=maybe-uninitialized]
 1998 |                 } else if (quoted && *s==quote_char) {
      |                            ~~~~~~~^~~~~~~~~~~~~~~~~
odbc.c:1990:14: note: 'quote_char' was declared here
 1990 |         char quote_char;
      |              ^~~~~~~~~~
```
The builds on armhf (32 bit system) is failing with the error:

```
In file included from /usr/include/stdio.h:970,
                 from mdb-sql.c:19:
In function ‘fgets’,
    inlined from ‘main’ at mdb-sql.c:423:9:
/usr/include/arm-linux-gnueabihf/bits/stdio2.h:313:12: error: argument 2 value -1 is negative [-Werror=stringop-overflow=]
  313 |     return __fgets_alias (__s, __n, __stream);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/features.h:510,
                 from /usr/include/arm-linux-gnueabihf/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:28:
/usr/include/arm-linux-gnueabihf/bits/stdio2-decl.h: In function ‘main’:
/usr/include/arm-linux-gnueabihf/bits/stdio2-decl.h:96:14: note: in a call to function ‘__fgets_alias’ declared with attribute ‘access (write_only, 1, 2)’
   96 | extern char *__REDIRECT (__fgets_alias,
      |              ^~~~~~~~~~
```
which is caused by overflowing because of the difference in size of 'unsigned int'.