### PR TITLE
Fix build failure with GCC 15+ due to old-style function declarations

### DIFF
--- a/src/util/mdb-sql.c
+++ b/src/util/mdb-sql.c
@@ -25,7 +25,7 @@
 #    include <readline.h>
 #  else
 /* no readline.h */
-extern char *readline ();
+extern char *readline (const char *);
 #  endif
 char *cmdline = NULL;
 #endif /* HAVE_LIBREADLINE */
@@ -37,10 +37,10 @@ char *cmdline = NULL;
 #    include <history.h>
 #  else
 /* no history.h */
-extern void add_history ();
-extern int write_history ();
-extern int read_history ();
-extern void clear_history ();
+extern void add_history (const char *);
+extern int write_history (const char *);
+extern int read_history (const char *);
+extern void clear_history (void);
 #  endif
 #endif /* HAVE_READLINE_HISTORY */
 


### PR DESCRIPTION
## Summary

- Fixes #452 — build fails on Fedora 42+ (and other distros with GCC 15+) because GCC 15 defaults to C23, where empty parentheses `()` in function declarations mean "takes zero parameters" instead of "unspecified parameters"
- Adds proper parameter types to the fallback `extern` declarations for `readline`, `add_history`, `write_history`, `read_history`, and `clear_history` in `src/util/mdb-sql.c`

## Test plan

- [x] Verified `make` succeeds after the fix on Fedora with GCC 15